### PR TITLE
Create cache directory if not exist

### DIFF
--- a/src/pipeline_migration/cli.py
+++ b/src/pipeline_migration/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os.path
 import tempfile
 from typing import Any, Final
 
@@ -97,6 +98,8 @@ def main() -> None:
     args = parser.parse_args()
 
     cache_dir = args.cache_dir or tempfile.mkdtemp(prefix=CACHE_DIR_PREFIX)
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
     FileBasedCache.configure(cache_dir=cache_dir)
 
     migrate(validate_upgrades(args.renovate_upgrades))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,3 +353,16 @@ def test_cli_stops_if_input_upgrades_is_invalid(upgrades, expected_err_msgs, mon
     assert entry_point() == 1
     for err_msg in expected_err_msgs:
         assert err_msg in caplog.text
+
+
+def test_ensure_cache_dir_is_created(tmp_path, monkeypatch):
+
+    def fake_migrate_method(*args, **kwargs):
+        """This method is used for test_ensure_cache_dir_is_created only"""
+
+    monkeypatch.setattr("pipeline_migration.cli.migrate", fake_migrate_method)
+    cache_dir = tmp_path / "cache"
+    cli_cmd = ["pmt", "-u", json.dumps(UPGRADES), "--cache-dir", str(cache_dir)]
+    monkeypatch.setattr("sys.argv", cli_cmd)
+    entry_point()
+    assert cache_dir.exists()


### PR DESCRIPTION
Related to STONEBLD-2824

This change makes it easy to run the Mintmaker container when no chance to create that directory before running the script.