### PR TITLE
Avoid requesting anonymous token by oras

### DIFF
--- a/src/pipeline_migration/registry.py
+++ b/src/pipeline_migration/registry.py
@@ -61,11 +61,20 @@ class Container(OrasContainer):
         return uri
 
 
+class AnonymousBackend:
+    """Custom backend to avoid extra HTTP requests by oras to request token"""
+
+
 class Registry(OrasRegistry):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._cache = FileBasedCache()
+
+        # oras determines backend type by checking the type of self.auth.
+        # Replace self.auth with the custom backend to avoid setting any
+        # authentication data in the header.
+        self.auth = AnonymousBackend()
 
     @staticmethod
     def _container_key(c: Container, digest: str | None = None) -> str:


### PR DESCRIPTION
All the operations are readonly to fetch data from Quay.io, so no need of extra HTTP requests to request anonymous tokens.