### PR TITLE
Resolve linked migrations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ skip_covered = true
 omit = [
   "tests/*"
 ]
+exclude_also = [
+    'raise NotImplementedError'
+]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/src/pipeline_migration/migrate.py
+++ b/src/pipeline_migration/migrate.py
@@ -4,6 +4,7 @@ import re
 import subprocess as sp
 import tempfile
 
+from abc import ABC, abstractmethod
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
@@ -18,6 +19,7 @@ from pipeline_migration.types import FilePath
 
 ANNOTATION_HAS_MIGRATION: Final[str] = "dev.konflux-ci.task.has-migration"
 ANNOTATION_IS_MIGRATION: Final[str] = "dev.konflux-ci.task.is-migration"
+ANNOTATION_PREVIOUS_MIGRATION_BUNDLE: Final[str] = "dev.konflux-ci.task.previous-migration-bundle"
 
 TEKTON_KIND_PIPELINE: Final = "Pipeline"
 TEKTON_KIND_PIPELINE_RUN: Final = "PipelineRun"
@@ -188,7 +190,7 @@ def determine_task_bundle_upgrades_range(
 
 class TaskBundleUpgradesManager:
 
-    def __init__(self, upgrades: list[dict[str, Any]]) -> None:
+    def __init__(self, upgrades: list[dict[str, Any]], resolver_class: type["Resolver"]) -> None:
         # Deduplicated task bundle upgrades. Key is the full bundle image with tag and digest.
         self._task_bundle_upgrades: dict[str, TaskBundleUpgrade] = {}
 
@@ -196,6 +198,8 @@ class TaskBundleUpgradesManager:
         # One package file may have the more than one task bundle upgrades, that reference the
         # objects in the ``_task_bundle_upgrades``.
         self._package_file_updates: dict[str, PackageFile] = {}
+
+        self._resolver = resolver_class()
 
         self._collect(upgrades)
 
@@ -242,42 +246,9 @@ class TaskBundleUpgradesManager:
                 pf = package_file
             pf.task_bundle_upgrades.append(tb_update)
 
-    @staticmethod
-    def _resolve_migrations_for_an_upgrade(
-        task_bundle_upgrade: TaskBundleUpgrade,
-    ) -> Generator[TaskBundleMigration, Any, None]:
-        upgrades_range = determine_task_bundle_upgrades_range(task_bundle_upgrade)
-        for tag_info in upgrades_range:
-            c = Container(task_bundle_upgrade.dep_name)
-            c.tag = tag_info.name
-            c.digest = tag_info.manifest_digest
-            uri_with_tag = c.uri_with_tag
-            script_content = fetch_migration_file(
-                task_bundle_upgrade.dep_name, tag_info.manifest_digest
-            )
-            if script_content:
-                logger.info("Task bundle %s has migration.", uri_with_tag)
-                yield TaskBundleMigration(task_bundle=uri_with_tag, migration_script=script_content)
-            else:
-                logger.info("Task bundle %s does not have migration.", uri_with_tag)
-
     def resolve_migrations(self) -> None:
         """Resolve migrations for given task bundle upgrades"""
-
-        def _resolve(tb_upgrade: TaskBundleUpgrade) -> None:
-            for tb_migration in self._resolve_migrations_for_an_upgrade(tb_upgrade):
-                tb_upgrade.migrations.append(tb_migration)
-            # Quay.io lists tags from the newest to the oldest one.
-            # Migrations must be applied in the reverse order.
-            tb_upgrade.migrations.reverse()
-
-        with ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(_resolve, tb_upgrade)
-                for tb_upgrade in self._task_bundle_upgrades.values()
-            ]
-            for future in as_completed(futures):
-                future.result()
+        self._resolver.resolve(list(self._task_bundle_upgrades.values()))
 
     @staticmethod
     def _apply_migration(pipeline_file: FilePath, migration: TaskBundleMigration) -> None:
@@ -334,11 +305,6 @@ def fetch_migration_file(image: str, digest: str) -> str | None:
     c.digest = digest
     registry = Registry()
 
-    manifest = registry.get_manifest(c)
-    has_migration = "true" == manifest.get("annotations", {}).get(ANNOTATION_HAS_MIGRATION, "false")
-    if not has_migration:
-        return None
-
     # query and fetch migration file via referrers API
     image_index = ImageIndex(data=registry.list_referrers(c, "text/x-shellscript"))
     descriptors = [
@@ -361,12 +327,118 @@ def fetch_migration_file(image: str, digest: str) -> str | None:
     return None
 
 
-def migrate(upgrades: list[dict[str, Any]]) -> None:
+def migrate(upgrades: list[dict[str, Any]], migration_resolver: type["Resolver"]) -> None:
     """The core method doing the migrations
 
     :param upgrades: upgrades data, that follows the schema of Renovate template field ``upgrades``.
     :type upgrades: list[dict[str, any]]
     """
-    manager = TaskBundleUpgradesManager(upgrades)
+    manager = TaskBundleUpgradesManager(upgrades, migration_resolver)
     manager.resolve_migrations()
     manager.apply_migrations()
+
+
+class Resolver(ABC):
+    """Base class for resolving migrations"""
+
+    @abstractmethod
+    def _resolve_migrations(
+        self, dep_name: str, upgrades_range: list[QuayTagInfo]
+    ) -> Generator[TaskBundleMigration, Any, None]:
+        raise NotImplementedError("Must be implemented in a subclass.")
+
+    def resolve(self, tb_upgrades: list[TaskBundleUpgrade]) -> None:
+        """Resolve migrations for given task bundles upgrades
+
+        Depending on the implementation of ``_resolve_migrations`` in subclasses, migrations are
+        resolved from remote, i.e. Quay.io, and put into the ``TaskBundleUpgrade.migrations`` in
+        place. This method ensures the migrations is in order from oldest to newest.
+        """
+
+        def _resolve(tb_upgrade: TaskBundleUpgrade) -> None:
+            upgrades_range = determine_task_bundle_upgrades_range(tb_upgrade)
+            for tb_migration in self._resolve_migrations(tb_upgrade.dep_name, upgrades_range):
+                tb_upgrade.migrations.append(tb_migration)
+            # Quay.io lists tags from the newest to the oldest one.
+            # Migrations must be applied in the reverse order.
+            tb_upgrade.migrations.reverse()
+
+        with ThreadPoolExecutor() as executor:
+            futures = [executor.submit(_resolve, tb_upgrade) for tb_upgrade in tb_upgrades]
+            for future in as_completed(futures):
+                future.result()
+
+
+class SimpleIterationResolver(Resolver):
+    """Legacy resolution by checking individual task bundle within an upgrade"""
+
+    def _resolve_migrations(
+        self, dep_name: str, upgrades_range: list[QuayTagInfo]
+    ) -> Generator[TaskBundleMigration, Any, None]:
+        """Resolve migration of individual task bundle one-by-one through the upgrade range"""
+
+        for tag_info in upgrades_range:
+            c = Container(f"{dep_name}:{tag_info.name}@{tag_info.manifest_digest}")
+            uri_with_tag = c.uri_with_tag
+
+            manifest_json = Registry().get_manifest(c)
+            if not is_true(
+                manifest_json.get("annotations", {}).get(ANNOTATION_HAS_MIGRATION, "false")
+            ):
+                continue
+
+            script_content = fetch_migration_file(dep_name, tag_info.manifest_digest)
+            if script_content:
+                logger.info("Task bundle %s has migration.", uri_with_tag)
+                yield TaskBundleMigration(task_bundle=uri_with_tag, migration_script=script_content)
+            else:
+                logger.info("Task bundle %s does not have migration.", uri_with_tag)
+
+
+class LinkedMigrationsResolver(Resolver):
+    """Resolve linked migrations via bundle image annotation"""
+
+    def _resolve_migrations(
+        self, dep_name: str, upgrades_range: list[QuayTagInfo]
+    ) -> Generator[TaskBundleMigration, Any, None]:
+        """Resolve migrations by links represented by annotation"""
+
+        manifest_digests = [tag.manifest_digest for tag in upgrades_range]
+        i = 0
+        while True:
+            tag_info = upgrades_range[i]
+            c = Container(f"{dep_name}:{tag_info.name}@{tag_info.manifest_digest}")
+            uri_with_tag = c.uri_with_tag
+
+            manifest_json = Registry().get_manifest(c)
+            has_migration = manifest_json.get("annotations", {}).get(
+                ANNOTATION_HAS_MIGRATION, "false"
+            )
+
+            if is_true(has_migration):
+                script_content = fetch_migration_file(dep_name, tag_info.manifest_digest)
+                if script_content:
+                    logger.info("Task bundle %s has migration.", uri_with_tag)
+                    yield TaskBundleMigration(
+                        task_bundle=uri_with_tag, migration_script=script_content
+                    )
+                else:
+                    logger.info("Task bundle %s does not have migration.", uri_with_tag)
+
+            digest = manifest_json.get("annotations", {}).get(
+                ANNOTATION_PREVIOUS_MIGRATION_BUNDLE, ""
+            )
+            if digest:
+                try:
+                    i = manifest_digests.index(digest)
+                except ValueError:
+                    logger.info(
+                        "Migration search stops at %s. It points to a previous migration bundle %s "
+                        "that is before the current upgrade.",
+                        c.uri_with_tag,
+                        digest,
+                    )
+                    break
+            else:
+                logger.info("Migration search stops at %s", c.uri_with_tag)
+                break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,24 @@
 import pytest
+from copy import deepcopy
+from typing import Final
+
+import responses
 
 from pipeline_migration.cache import FileBasedCache
 from pipeline_migration.types import DescriptorT, ManifestT
 from pipeline_migration.registry import (
+    Container,
     MEDIA_TYPE_OCI_IMAGE_CONFIG_V1,
     MEDIA_TYPE_OCI_IMAGE_LAYER_V1_TAR_GZ,
     MEDIA_TYPE_OCI_IMAGE_MANIFEST_V1,
 )
+from pipeline_migration.migrate import (
+    ANNOTATION_HAS_MIGRATION,
+    ANNOTATION_IS_MIGRATION,
+    ANNOTATION_PREVIOUS_MIGRATION_BUNDLE,
+    ANNOTATION_TRUTH_VALUE,
+)
+from tests.utils import generate_digest
 
 
 @pytest.fixture()
@@ -59,3 +71,54 @@ def oci_image_descriptor() -> DescriptorT:
 def oci_referrer_descriptor(oci_image_descriptor) -> DescriptorT:
     oci_image_descriptor["artifactType"] = "text/plain"
     return oci_image_descriptor
+
+
+@pytest.fixture
+def migration_content() -> bytes:
+    return b"echo hello world"
+
+
+@pytest.fixture
+def mock_fetch_migration(oci_referrer_descriptor, image_manifest, migration_content):
+    """Mock HTTP requests for method fetch_migration_file"""
+
+    def _mock(c: Container, migration_content: bytes = migration_content) -> None:
+        # mock there is a referrer with specific artifactType and annotation
+        oci_referrer_descriptor["annotations"] = {ANNOTATION_IS_MIGRATION: ANNOTATION_TRUTH_VALUE}
+        image_index = {
+            "schemaVersion": 2,
+            "manifests": [oci_referrer_descriptor],
+            "annotations": {},
+        }
+        responses.get(
+            f"https://{c.referrers_url}?artifactType=text/x-shellscript", json=image_index
+        )
+
+        layer_digest: Final = generate_digest()
+
+        # mock getting referrer image manifest
+        referrer_manifest = deepcopy(image_manifest)
+        referrer_manifest["layers"][0]["digest"] = layer_digest
+        c.digest = oci_referrer_descriptor["digest"]
+        responses.get(f"https://{c.manifest_url()}", json=referrer_manifest)
+
+        # mock getting referrer's layer blob, i.e. the content
+        responses.get(f"https://{c.get_blob_url(layer_digest)}", body=migration_content)
+
+    return _mock
+
+
+@pytest.fixture
+def mock_get_manifest(image_manifest):
+    """Mock get_manifest for image represented by a Container object"""
+
+    def _mock(c: Container, has_migration=False, previous_migration_bundle: str | None = None):
+        manifest_json = deepcopy(image_manifest)
+        annotations = manifest_json["annotations"]
+        if has_migration:
+            annotations[ANNOTATION_HAS_MIGRATION] = ANNOTATION_TRUTH_VALUE
+        if previous_migration_bundle is not None:
+            annotations[ANNOTATION_PREVIOUS_MIGRATION_BUNDLE] = previous_migration_bundle
+        responses.add(responses.GET, f"https://{c.manifest_url()}", json=manifest_json)
+
+    return _mock


### PR DESCRIPTION
STONEBLD-3214

This commit adds an additional migration resolver by checking annotation against task bundles, which is used to link task bundles which have migrations.

This feature relies on adding the annotation to task bundles during build and push process.

The original behavior of fetching migrations by iterating task bundles within an upgrade is retained as a legacy resolver. It can be enabled by passing argument `--use-legacy-resolver` from the command line.

Major changes:

* Resolver and subclasses contain the core logic to support the two resolvers.
* Add a command line argument `--use-legacy-resolver` to enable the original behavior.
* Update tests accordingly with refactors for writing tests easier.