### PR TITLE
Retain block sequence indentation

### DIFF
--- a/src/pipeline_migration/utils.py
+++ b/src/pipeline_migration/utils.py
@@ -1,17 +1,100 @@
+from dataclasses import dataclass, field
 from typing import Any
-from ruamel.yaml import YAML
 
 from pipeline_migration.types import FilePath
+
+from ruamel.yaml import YAML, CommentedMap, CommentedSeq
+from ruamel.yaml.comments import CommentedBase
+
+
+__all__ = [
+    "BlockSequenceIndentation",
+    "create_yaml_obj",
+    "dump_yaml",
+    "is_true",
+    "load_yaml",
+    "YAMLStyle",
+]
 
 
 def is_true(value: str) -> bool:
     return value.strip().lower() == "true"
 
 
-def create_yaml_obj():
+@dataclass
+class BlockSequenceIndentation:
+    indentations: dict[int, int] = field(default_factory=dict)
+
+    @property
+    def is_consistent(self) -> bool:
+        return len(self.levels) == 1
+
+    @property
+    def levels(self) -> list[int]:
+        return list(self.indentations.keys())
+
+
+@dataclass
+class _NodePath:
+    node: CommentedBase
+    field: str = ""
+
+
+@dataclass
+class YAMLStyle:
+    indentation: BlockSequenceIndentation
+
+    preserve_quotes: bool = True
+    width: int = 8192
+
+    @classmethod
+    def _detect_block_sequence_indentation(cls, node: CommentedBase) -> BlockSequenceIndentation:
+
+        parent_nodes: list[_NodePath] = []
+        block_seq_indentations = BlockSequenceIndentation()
+        indentations = block_seq_indentations.indentations
+
+        def _walk(node: CommentedBase) -> None:
+            if isinstance(node, CommentedMap):
+                parent_nodes.append(_NodePath(node=node))
+                for key, value in node.items():
+                    parent_nodes[-1].field = key
+                    _walk(value)
+                parent_nodes.pop()
+            elif isinstance(node, CommentedSeq):
+                levels = node.lc.col - parent_nodes[-1].node.lc.col
+                if levels in indentations:
+                    indentations[levels] += 1
+                else:
+                    indentations[levels] = 1
+                for item in node:
+                    _walk(item)
+
+        _walk(node)
+
+        return block_seq_indentations
+
+    @classmethod
+    def detect(cls, file_path: FilePath) -> "YAMLStyle":
+        doc = load_yaml(file_path)
+        indentation = cls._detect_block_sequence_indentation(doc)
+        return cls(indentation=indentation)
+
+
+def create_yaml_obj(style: YAMLStyle | None = None):
     yaml = YAML()
-    yaml.preserve_quotes = True
-    yaml.width = 8192
+    if style is None:
+        return yaml
+
+    yaml.preserve_quotes = style.preserve_quotes
+    yaml.width = style.width
+
+    offset = 0
+    if style.indentation.is_consistent:
+        offset = style.indentation.levels[0]
+    sequence = offset + 2
+    yaml.indent(sequence=sequence, offset=offset)
+
     return yaml
 
 
@@ -20,6 +103,6 @@ def load_yaml(yaml_file: FilePath) -> Any:
         return create_yaml_obj().load(f)
 
 
-def dump_yaml(yaml_file: FilePath, data: Any):
+def dump_yaml(yaml_file: FilePath, data: Any, style: YAMLStyle | None = None) -> None:
     with open(yaml_file, "w", encoding="utf-8") as f:
-        create_yaml_obj().dump(data, f)
+        create_yaml_obj(style).dump(data, f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from copy import deepcopy
+from textwrap import dedent
 from typing import Final
 
 import responses
@@ -107,3 +108,43 @@ def mock_get_manifest(image_manifest):
         responses.add(responses.GET, f"https://{c.manifest_url()}", json=manifest_json)
 
     return _mock
+
+
+@pytest.fixture
+def pipeline_yaml():
+    return dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: pl
+        spec:
+          tasks:
+          - name: clone
+            image: debian:latest
+            script: |
+              git clone https://git.host/project
+        """
+    )
+
+
+@pytest.fixture(params=["no_indents", "2_spaces_indents"])
+def pipeline_yaml_with_various_indent_styles(request, pipeline_yaml):
+    match request.param:
+        case "no_indents":
+            return pipeline_yaml
+        case "2_spaces_indents":
+            return dedent(
+                """\
+                apiVersion: tekton.dev/v1
+                kind: Pipeline
+                metadata:
+                  name: pl
+                spec:
+                  tasks:
+                    - name: clone
+                      image: debian:latest
+                      script: |
+                        git clone https://git.host/project
+                """
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 from textwrap import dedent
-from pipeline_migration.utils import YAMLStyle, dump_yaml, BlockSequenceIndentation
+from pipeline_migration.utils import YAMLStyle, dump_yaml, load_yaml, BlockSequenceIndentation
 
 YAML_EXAMPLE_0_INDENT = """\
 apiVersion: tekton.dev/v1
@@ -122,3 +122,14 @@ def test_dump_yaml_with_style(style, data, expected_yaml, tmp_path):
     yaml_file = tmp_path / "file.yaml"
     dump_yaml(yaml_file, data, style=style)
     assert yaml_file.read_text() == expected_yaml
+
+
+@pytest.mark.parametrize("yaml_content", [YAML_EXAMPLE_0_INDENT, YAML_EXAMPLE_2_INDENTS])
+def test_dump_same_yaml_with_consistent_indentation_formatting(yaml_content, tmp_path):
+    yaml_file = tmp_path / "file.yaml"
+    yaml_file.write_text(yaml_content)
+    style = YAMLStyle.detect(yaml_file)
+    doc = load_yaml(yaml_file)
+    new_file = tmp_path / "new.yaml"
+    dump_yaml(new_file, doc, style)
+    assert yaml_file.read_text() == new_file.read_text()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,124 @@
+import pytest
+from textwrap import dedent
+from pipeline_migration.utils import YAMLStyle, dump_yaml, BlockSequenceIndentation
+
+YAML_EXAMPLE_0_INDENT = """\
+apiVersion: tekton.dev/v1
+spec:
+  params:
+  - name: git-url
+    type: string
+  - name: revision
+    type: string
+  tasks:
+  - name: clone-repository
+  - name: build-container
+"""
+
+YAML_EXAMPLE_2_INDENTS = """\
+apiVersion: tekton.dev/v1
+spec:
+  params:
+    - name: git-url
+      type: string
+    - name: revision
+      type: string
+  tasks:
+    - name: clone-repository
+    - name: build-container
+"""
+
+YAML_EXAMPLE_MIXED_INDENT_LEVELS = """\
+apiVersion: tekton.dev/v1
+spec:
+  params:
+    - name: git-url
+      type: string
+    - name: revision
+      type: string
+  tasks:
+  - name: clone-repository
+    params:
+     - name: git-url
+     - name: revision
+  - name: build-container
+    params:
+     - name: git-url
+     - name: revision
+  finally:
+       - name: show-summary
+       - name: show-sbom
+"""
+
+
+@pytest.mark.parametrize(
+    "yaml,expected",
+    [
+        [YAML_EXAMPLE_0_INDENT, [True, {0: 2}]],
+        [YAML_EXAMPLE_2_INDENTS, [True, {2: 2}]],
+        [YAML_EXAMPLE_MIXED_INDENT_LEVELS, [False, {2: 1, 0: 1, 1: 2, 5: 1}]],
+    ],
+)
+def test_indentation_detection(yaml, expected, tmp_path):
+    yaml_file = tmp_path / "file.yaml"
+    yaml_file.write_text(yaml)
+    ys = YAMLStyle.detect(yaml_file)
+    is_consistent, levels = expected
+    assert ys.indentation.is_consistent == is_consistent
+    assert ys.indentation.levels == list(levels.keys())
+    assert ys.indentation.indentations == levels
+
+
+@pytest.mark.parametrize(
+    "style,data,expected_yaml",
+    [
+        [
+            None,
+            {"params": [{"name": "git-url"}, {"name": "revision"}]},
+            dedent(
+                """\
+                params:
+                - name: git-url
+                - name: revision
+                """
+            ),
+        ],
+        [
+            YAMLStyle(indentation=BlockSequenceIndentation(indentations={0: 1})),
+            {"params": [{"name": "git-url"}, {"name": "revision"}]},
+            dedent(
+                """\
+                params:
+                - name: git-url
+                - name: revision
+                """
+            ),
+        ],
+        [
+            YAMLStyle(indentation=BlockSequenceIndentation(indentations={2: 1})),
+            {"params": [{"name": "git-url"}, {"name": "revision"}]},
+            dedent(
+                """\
+                params:
+                  - name: git-url
+                  - name: revision
+                """
+            ),
+        ],
+        [
+            YAMLStyle(indentation=BlockSequenceIndentation(indentations={2: 2, 0: 10, 3: 1})),
+            {"params": [{"name": "git-url"}, {"name": "revision"}]},
+            dedent(
+                """\
+                params:
+                - name: git-url
+                - name: revision
+                """
+            ),
+        ],
+    ],
+)
+def test_dump_yaml_with_style(style, data, expected_yaml, tmp_path):
+    yaml_file = tmp_path / "file.yaml"
+    dump_yaml(yaml_file, data, style=style)
+    assert yaml_file.read_text() == expected_yaml


### PR DESCRIPTION
STONEBLD-3422

Users may use various block sequence indentation styles for themselves that are different from the one proposed by Konflux during the onboard. This commit tries to detect the indentation styles used in the users side and retain the style as much as possible in order to not introduce big formatting change to users. The tool does:

* if block sequence indentation style is used consistently with same levels through the whole file, whatever 0, 2, or 4, the result pipeline keeps same style.
* if various styles are mixed, the block sequneces are formatted without indentation in the result pipeline.

This commit makes these changes mainly:

* Add a new class YAMLStyle for detecting the indentation sytles.
* YAML related methods in utils.py are extended to support dumping data with styles.
* Move fixed styles width and preserve_quotes into YAMLStyle class.
* resolve_pipeline method ensures the styles are detected and save the pipeline with detected style.
* Tests are added and updated accordingly. The tests involves YAMLs with different styles of block sequence indentations, then part of the test code are refactored with pytest fixture in order to write tests easily.