### PR TITLE
Do not dump pipeline YAML if no migration is applied

### DIFF
--- a/src/pipeline_migration/utils.py
+++ b/src/pipeline_migration/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -106,3 +107,8 @@ def load_yaml(yaml_file: FilePath) -> Any:
 def dump_yaml(yaml_file: FilePath, data: Any, style: YAMLStyle | None = None) -> None:
     with open(yaml_file, "w", encoding="utf-8") as f:
         create_yaml_obj(style).dump(data, f)
+
+
+def file_checksum(file_path: FilePath) -> str:
+    with open(file_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,3 +148,34 @@ def pipeline_yaml_with_various_indent_styles(request, pipeline_yaml):
                         git clone https://git.host/project
                 """
             )
+        case _:
+            raise ValueError(f"Unexpected param {request.param}")
+
+
+@pytest.fixture
+def pipeline_run_yaml() -> str:
+    return dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: docker-build
+        spec:
+          pipelineSpec:
+            params:
+            tasks:
+            - name: clone
+            - name: build
+        """
+    )
+
+
+@pytest.fixture(params=["pipeline", "pipeline_run"])
+def pipeline_and_run_yaml(request, pipeline_yaml, pipeline_run_yaml) -> str:
+    match request.param:
+        case "pipeline":
+            return pipeline_yaml
+        case "pipeline_run":
+            return pipeline_run_yaml
+        case _:
+            raise ValueError(f"Unexpected param {request.param}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ from pipeline_migration.registry import (
     ensure_container,
 )
 
-from pipeline_migration.utils import YAMLStyle
+from pipeline_migration.utils import YAMLStyle, load_yaml, dump_yaml
 from tests.test_migrate import APP_IMAGE_REPO, TASK_BUNDLE_CLONE
 from tests.utils import generate_digest, generate_git_sha
 
@@ -296,6 +296,12 @@ class TestMigrateSingleTaskBundleUpgrade:
             assert pipeline_file == tb_upgrades[0]["packageFile"]
             migration_file = cmd[-2]
             assert Path(migration_file).read_bytes() in migration_steps
+
+            # Modify the pipeline as if a migration is applied
+            doc = load_yaml(pipeline_file)
+            doc["spec"]["tasks"] += {"name": "summary"}
+            dump_yaml(pipeline_file, doc)
+
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
         monkeypatch.setattr("subprocess.run", _subprocess_run)


### PR DESCRIPTION
STONEBLD-3438

* Compute file hash to detect if the pipeline is modified.
* New test is added, and by the way, the existing tests are refactored
  with fixtures for adding the new test.
* Test test_ensure_updates_to_pipeline_are_saved is renamed to reflect
  the test purpose specifically.