### PR TITLE
fix: empty upgrade range does not break LinkedMigrationsResolver

### DIFF
--- a/src/pipeline_migration/actions/migrate.py
+++ b/src/pipeline_migration/actions/migrate.py
@@ -447,6 +447,10 @@ class LinkedMigrationsResolver(Resolver):
     ) -> Generator[TaskBundleMigration, Any, None]:
         """Resolve migrations by links represented by annotation"""
 
+        if not upgrades_range:
+            logger.info("Upgrade range is empty for %s. Skip resolving migrations.", dep_name)
+            return
+
         manifest_digests = [tag.manifest_digest for tag in upgrades_range]
         i = 0
         while True:


### PR DESCRIPTION
In case a bundle image repository does not have tags within known scheme, i.e. <version>-<commit hash>, the upgrade range will be emtpy. LinkedMigrationsResolver._resolve_migrations did not check the input empty list of tags.