### PR TITLE
List bundle tags by versions explicitly

### DIFF
--- a/src/pipeline_migration/quay.py
+++ b/src/pipeline_migration/quay.py
@@ -13,7 +13,9 @@ class QuayTagInfo:
     manifest_digest: str
 
 
-def list_active_repo_tags(c: Container, tag_name: str = "") -> Generator[dict, Any, None]:
+def list_active_repo_tags(
+    c: Container, tag_name: str = "", tag_name_pattern: str = ""
+) -> Generator[dict, Any, None]:
     """List repository tags
 
     Make GET HTTP request to Quay API ``listRepoTags``.
@@ -26,6 +28,8 @@ def list_active_repo_tags(c: Container, tag_name: str = "") -> Generator[dict, A
         params = {"page": str(page), "onlyActiveTags": "true"}
         if tag_name:
             params["specificTag"] = tag_name
+        if tag_name_pattern:
+            params["filter_tag_name"] = f"like:{tag_name_pattern}"
         api_url = f"https://{c.registry}/api/v1/repository/{c.namespace}/{c.repository}/tag/"
         resp = requests.get(api_url, params=params)
         resp.raise_for_status()

--- a/tests/actions/test_migrate_cli.py
+++ b/tests/actions/test_migrate_cli.py
@@ -170,6 +170,7 @@ task_bundle_clone_test_data = ImageTestData(
 )
 
 
+# TODO: make this fixture to be reusable
 def mock_quay_list_tags(image_repo: str, tags: list[dict]) -> None:
     assert image_repo != ""
     api_url = f"https://quay.io/api/v1/repository/{image_repo}/tag/"


### PR DESCRIPTION
The major difficulty of determining the upgrade range is to identify the range start and end. Since bundles can be built from an old version, even any older ones, the tags responded by Quay.io listRepoTags endpoint are mixed with different versions through the timeline from newest to oldes. For possible cases, please refer to the test, which contains various potential cases as much as possible.

This patch proposes a new mechanism to list tags by versions explicitly rather than trying to handle different cases by iterating tags linearly. As a result, irrelevant tags will not be present in the tag list, and it is much easier to drop out-of-order tags without noise.

This way requires to version expansion according to the old and new version, for example, upgrade from current value 0.2 to new value 0.4, it will be expanded to 0.2, 0.3 and 0.4. This expansion relies on the current task version management strategy used by build-definitions.