### PR TITLE
Add Python 3.13 support to tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py312,black,flake8,mypy
+env_list = py312,py313,black,flake8,mypy
 
 [testenv]
 use_develop = True


### PR DESCRIPTION
Updates tox envlist to use py313 together with py312, enabling Python 3.13 compatibility testing.

🤖 Generated with [Claude Code](https://claude.ai/code)

Assisted-By: Claude <noreply@anthropic.com>

(this cost ~~$0.40~~ $0.68 in API tokens, future is amazing)