### PR TITLE
pmt modify: generic sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,37 @@ the same with `pmt modify`:
 Get more information about supported resources by `pmt modify -h`, and supported commands
 for the given resource by `pmt modify RESOURCE -h` (for example `pmt modify task -h`).
 
+#### Unsupported resource?
+
+When resource you need is not supported by `pmt modify` you can use `generic` subcommand
+which processes raw YAML text without semantic validation but tries to keep minimal changes
+done to the YAML file.
+
+It's not recommended to use this subcommand if specific resource subcommand exists.
+
+Sub-command `generic` supports following operations: `insert`, `replace`, and `remove`.
+
+Each operation requires a YAML path to the target item.
+Yaml path is sequence of indexes (compatible with `yq`'s `path` function):
+
+```yaml
+- spec
+- tasks
+- 5
+```
+
+Also singleline notation using YAML flow style can be used:`["spec", "tasks", 5]`.
+Item to be updated must be sequence or map type.
+
+Example using yq:
+```bash
+    pmt modify \\
+      -f .tekton/pr.yaml \\
+      generic remove \\
+      "$(yq '.spec.pipelineSpec.tasks[] | select(.name == "prefetch-dependencies") | \\
+         path' .tekton/pr.yaml)"
+```
+
 #### Known issues
 
 Subcommand `modify` has following known issues
@@ -184,7 +215,7 @@ This integration test sets up a testing environment, inside which tasks are buil
 
 Prerequisite:
 
-- A local clone of [konflux-ci/build-definitions](https://github.com/konflux-ci/build-definitions) 
+- A local clone of [konflux-ci/build-definitions](https://github.com/konflux-ci/build-definitions)
   and checkout to `main` branch.
 - Create public image repositories `task-clone` and `task-lint` under specified `QUAY_NAMESPACE`.
 - Log into Quay.io in order to make `tkn-bundle-push` work.

--- a/src/pipeline_migration/actions/modify/__init__.py
+++ b/src/pipeline_migration/actions/modify/__init__.py
@@ -2,6 +2,7 @@ import argparse
 from typing import Final
 
 from pipeline_migration.actions.modify.task import register_cli as register_mod_task_cli
+from pipeline_migration.actions.modify.generic import register_cli as register_mod_generic_cli
 
 SUBCMD_DESCRIPTION: Final = """\
 Allows to modify existing resources in Konflux pipelines/pipeline runs.
@@ -32,3 +33,4 @@ def register_cli(subparser) -> None:
         title="subcommands to manage given resources", required=True
     )
     register_mod_task_cli(subparser_modify)
+    register_mod_generic_cli(subparser_modify)

--- a/src/pipeline_migration/actions/modify/generic.py
+++ b/src/pipeline_migration/actions/modify/generic.py
@@ -1,0 +1,318 @@
+import argparse
+import copy
+import logging
+from pathlib import Path
+from typing import Any, Final
+
+from ruamel.yaml.comments import CommentedSeq, CommentedMap
+
+from pipeline_migration.yamleditor import EditYAMLEntry, YAMLPath
+from pipeline_migration.types import FilePath
+from pipeline_migration.utils import YAMLStyle, create_yaml_obj
+from pipeline_migration.pipeline import PipelineFileOperation, iterate_files_or_dirs
+
+
+logger = logging.getLogger("modify.generic")
+
+
+SUBCMD_DESCRIPTION: Final = """\
+
+Subcommanad "generic" requires path within the YAML doc in "yq" path function style,
+where an operation should be executed.
+
+YAML path is list of indexes in YAML format.
+For example:
+- spec
+- tasks
+- 5
+
+It can be also written on singleline in YAML flow format: '["spec", "tasks", 5]'.
+
+The following are several examples with a raw yaml modification:
+
+* Modify an yaml item within relative .tekton/ directory.
+
+    cd /path/to/repo
+    pmt modify generic insert '["path", "to", "yaml", "item"]' '{"new": "item"}'
+
+* Modify an yaml item in multiple pipelines in several repositories:
+
+    pmt modify \\
+        -f /path/to/repo1/.tekton/pr.yaml -f /path/to/repo2/.tekton/push.yaml \\
+        generic replace \\
+        '["path", "to", "yaml", "item", 3]' '{"replaced": "new"}'
+
+* Remove a task using yq's `path` function:
+
+   pmt modify \\
+        -f .tekton/pr.yaml \\
+        generic remove \\
+        "$(yq '.spec.pipelineSpec.tasks[] | select(.name == "prefetch-dependencies") | \\
+            path' .tekton/pr.yaml)"
+
+WARNING: generic subcommand should be used as the last resort subcommand, it doesn't do any
+semantic validation for Konflux tasks.
+Use resource specific subcommands if they are available instead to have a proper validation.
+"""
+
+
+class YAMLPathNotFoundError(Exception):
+    """Exception when given path doesn't exist in the YAML doc"""
+
+
+def _yaml_path_from_param(yaml_path_param: str) -> YAMLPath:
+    """Parses and validates yaml_path parameter and returns YAMLPath variable type"""
+    yaml = create_yaml_obj()
+    loaded_path_params = yaml.load(yaml_path_param)
+
+    yaml_path: YAMLPath = []
+
+    if not isinstance(loaded_path_params, list):
+        raise ValueError("Provided YAML path must be a sequence")
+
+    for item in loaded_path_params:
+        if not isinstance(item, (str, int)):
+            raise ValueError(
+                "Provided YAML path sequence must contain only string or integer values"
+            )
+        yaml_path.append(item)
+
+    return yaml_path
+
+
+def yaml_path_type(param: str) -> YAMLPath:
+    "Argparser custom type for yaml path validation"
+    try:
+        yaml_path = _yaml_path_from_param(param)
+    except Exception as e:
+        raise argparse.ArgumentTypeError(str(e))
+    else:
+        return yaml_path
+
+
+def _yaml_from_value_param(value: str) -> dict | list:
+    """Parses and validates value param"""
+
+    def make_block_style_yaml(y):
+        """Recursively updates"""
+        if not hasattr(y, "fa"):
+            # scalar node, nothing to do
+            return
+
+        y.fa.set_block_style()
+
+        if isinstance(y, dict):
+            for item in y.values():
+                make_block_style_yaml(item)
+        if isinstance(y, list):
+            for item in y:
+                make_block_style_yaml(item)
+
+    yaml = create_yaml_obj()
+    loaded_value = yaml.load(value)
+
+    if not isinstance(loaded_value, (list, dict)):
+        raise ValueError("Value parameter must be YAML sequence or map")
+
+    make_block_style_yaml(loaded_value)
+
+    return loaded_value
+
+
+def yaml_value_type(param: str) -> dict | list:
+    "Argparser custom type for yaml value validation"
+    try:
+        yaml_path = _yaml_from_value_param(param)
+    except Exception as e:
+        raise argparse.ArgumentTypeError(str(e))
+    else:
+        return yaml_path
+
+
+def register_cli(subparser) -> None:
+    mod_generic_parser = subparser.add_parser(
+        "generic",
+        help=(
+            "Generic modification of YAML file (specific resource subcommands should "
+            "be preferred)"
+        ),
+        description=SUBCMD_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    subparser_mod = mod_generic_parser.add_subparsers(
+        title="subcommands to generic modifications", required=True
+    )
+
+    # insert
+    subparser_insert = subparser_mod.add_parser(
+        "insert",
+        help="Inserts item into YAML path",
+    )
+    subparser_insert.add_argument(
+        "yaml_path",
+        help=(
+            "YAML path (in YAML format). Must point to a sequence or a map item. "
+            "It's the same path as returned by yq's path function (list of indexes)"
+        ),
+        metavar="YAML-PATH",
+        type=yaml_path_type,
+    )
+    subparser_insert.add_argument(
+        "value",
+        help="YAML sequence or map (in YAML format) to be inserted)",
+        metavar="VALUE",
+        type=yaml_value_type,
+    )
+
+    subparser_insert.set_defaults(action=action_insert)
+
+    # replace
+    subparser_replace = subparser_mod.add_parser(
+        "replace",
+        help="Replaces item at given YAML path",
+    )
+    subparser_replace.add_argument(
+        "yaml_path",
+        help=(
+            "YAML path (in YAML format). Must point to a sequence or a map item. "
+            "It's the same path as returned by yq's path function (list of indexes)"
+        ),
+        metavar="YAML-PATH",
+        type=yaml_path_type,
+    )
+    subparser_replace.add_argument(
+        "value",
+        help="YAML sequence or map (in YAML format) to be used as the replacement)",
+        metavar="VALUE",
+        type=yaml_value_type,
+    )
+
+    subparser_replace.set_defaults(action=action_replace)
+
+    # remove
+    subparser_remove = subparser_mod.add_parser(
+        "remove",
+        help="Removes item at given YAML path",
+    )
+    subparser_remove.add_argument(
+        "yaml_path",
+        help=(
+            "YAML path (in YAML format). Must point to a sequence or a map item. "
+            "It's the same path as returned by yq's path function (list of indexes)"
+        ),
+        metavar="YAML-PATH",
+        type=yaml_path_type,
+    )
+
+    subparser_remove.set_defaults(action=action_remove)
+
+
+class ModGenericBase(PipelineFileOperation):
+    """Base class for generic resource modifications"""
+
+    def __init__(self, yaml_path: YAMLPath):
+        self.yaml_path = yaml_path
+
+    def validate_yaml_path(self, loaded_doc: Any):
+        def get_path_doc(ypath):
+            """:raises KeyError: when path doesn't exist"""
+            tmp_doc = copy.copy(loaded_doc)
+            for p in ypath:
+                tmp_doc = tmp_doc[p]
+            return tmp_doc
+
+        try:
+            tmp_doc = get_path_doc(self.yaml_path)
+        except KeyError:
+            raise YAMLPathNotFoundError(
+                f"Given YAML path {self.yaml_path} doesn't exist in the doc"
+            )
+        else:
+            if not isinstance(tmp_doc, (CommentedSeq, CommentedMap)):
+                raise RuntimeError(
+                    f"Provided YAML path {self.yaml_path} must point to sequence or map"
+                )
+
+    def handle_pipeline_run_file(
+        self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle
+    ) -> None:
+        # the same implementation as pipeline
+        self.handle_pipeline_file(file_path, loaded_doc, style)
+
+
+class ModGenericInsert(ModGenericBase):
+    def __init__(self, yaml_path: YAMLPath, value: dict | list):
+        super().__init__(yaml_path)
+        self.value = value
+
+    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        logger.info("Inserting content into YAML path %s in file %s", self.yaml_path, file_path)
+        self.validate_yaml_path(loaded_doc)
+        yamledit = EditYAMLEntry(file_path, style=style)
+        yamledit.insert(self.yaml_path, self.value)
+
+
+def action_insert(args) -> None:
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+
+    op = ModGenericInsert(args.yaml_path, args.value)
+    for file_path in iterate_files_or_dirs(search_places):
+        try:
+            op.handle(str(file_path))
+        except YAMLPathNotFoundError as e:
+            logger.warning("Skipped file %s update: %s", file_path, e)
+
+
+class ModGenericReplace(ModGenericBase):
+    def __init__(self, yaml_path: YAMLPath, value: dict | list):
+        super().__init__(yaml_path)
+        self.value = value
+
+    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        logger.info("Replacing content at YAML path %s in file %s", self.yaml_path, file_path)
+        self.validate_yaml_path(loaded_doc)
+        yamledit = EditYAMLEntry(file_path, style=style)
+        yamledit.replace(self.yaml_path, self.value)
+
+
+def action_replace(args) -> None:
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+
+    op = ModGenericReplace(args.yaml_path, args.value)
+    for file_path in iterate_files_or_dirs(search_places):
+        try:
+            op.handle(str(file_path))
+        except YAMLPathNotFoundError as e:
+            logger.warning("Skipped file %s update: %s", file_path, e)
+
+
+class ModGenericRemove(ModGenericBase):
+    def __init__(self, yaml_path: YAMLPath):
+        super().__init__(yaml_path)
+
+    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        logger.info("Removing YAML path %s in file %s", self.yaml_path, file_path)
+        self.validate_yaml_path(loaded_doc)
+        yamledit = EditYAMLEntry(file_path, style=style)
+        yamledit.delete(self.yaml_path)
+
+
+def action_remove(args) -> None:
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+
+    op = ModGenericRemove(args.yaml_path)
+    for file_path in iterate_files_or_dirs(search_places):
+        try:
+            op.handle(str(file_path))
+        except YAMLPathNotFoundError as e:
+            logger.warning("Skipped file %s update: %s", file_path, e)

--- a/tests/actions/modify/test_generic.py
+++ b/tests/actions/modify/test_generic.py
@@ -1,0 +1,683 @@
+import pytest
+from pathlib import Path
+from textwrap import dedent
+
+from pipeline_migration.actions.modify.generic import (
+    ModGenericInsert,
+    ModGenericReplace,
+    ModGenericRemove,
+    YAMLPathNotFoundError,
+    _yaml_path_from_param,
+    _yaml_from_value_param,
+)
+from pipeline_migration.utils import load_yaml, YAMLStyle
+
+
+def read_file_content(file_path: Path) -> str:
+    """Helper function to read file content."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture
+def pipeline_yaml_file(create_yaml_file):
+    """Create a temporary YAML file with a pipeline structure."""
+    content = dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+              params:
+                - name: url
+                  value: "https://github.com/example/repo"
+                - name: revision
+                  value: "main"
+            - name: build
+              taskRef:
+                name: buildah
+              params:
+                - name: IMAGE
+                  value: "registry.io/app:latest"
+          params:
+            - name: repo-url
+              value: "https://github.com/default/repo"
+        """
+    )
+
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_run_yaml_file(create_yaml_file):
+    """Create a temporary YAML file with a PipelineRun structure."""
+    content = dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            tasks:
+              - name: clone
+                taskRef:
+                  name: git-clone
+                params:
+                  - name: url
+                    value: "https://github.com/example/repo"
+              - name: build
+                taskRef:
+                  name: buildah
+            params:
+              - name: global-param
+                value: "global-value"
+        """
+    )
+
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def simple_yaml_file(create_yaml_file):
+    """Create a simple YAML file for testing."""
+    content = dedent(
+        """\
+        root:
+          level1:
+            items:
+              - name: item1
+                value: 1
+              - name: item2
+                value: 2
+            config:
+              setting1: "value1"
+              setting2: "value2"
+        """
+    )
+
+    return create_yaml_file(content)
+
+
+class TestYAMLPathFromParam:
+    """Test cases for yaml_path_from_param function."""
+
+    def test_valid_yaml_path_list(self):
+        """Test parsing a valid YAML path list."""
+        yaml_path_str = '["spec", "tasks", 0, "params"]'
+        result = _yaml_path_from_param(yaml_path_str)
+        assert result == ["spec", "tasks", 0, "params"]
+
+    def test_valid_yaml_path_mixed_types(self):
+        """Test parsing a YAML path with mixed string and integer types."""
+        yaml_path_str = '["metadata", "name"]'
+        result = _yaml_path_from_param(yaml_path_str)
+        assert result == ["metadata", "name"]
+
+    def test_empty_yaml_path(self):
+        """Test parsing an empty YAML path."""
+        yaml_path_str = "[]"
+        result = _yaml_path_from_param(yaml_path_str)
+        assert result == []
+
+    def test_invalid_yaml_path_not_list(self):
+        """Test error when YAML path is not a list."""
+        yaml_path_str = '"not_a_list"'
+        with pytest.raises(ValueError, match="Provided YAML path must be a sequence"):
+            _yaml_path_from_param(yaml_path_str)
+
+    def test_invalid_yaml_path_invalid_types(self):
+        """Test error when YAML path contains invalid types."""
+        yaml_path_str = '["valid", 1.5, "string"]'
+        with pytest.raises(ValueError, match="must contain only string or integer values"):
+            _yaml_path_from_param(yaml_path_str)
+
+    def test_invalid_yaml_syntax(self):
+        """Test error when YAML syntax is invalid."""
+        yaml_path_str = '["unclosed", list'
+        with pytest.raises(Exception):  # YAML parsing error
+            _yaml_path_from_param(yaml_path_str)
+
+
+class TestYAMLFromValueParam:
+    """Test cases for yaml_from_value_param function."""
+
+    def test_valid_yaml_dict(self):
+        """Test parsing a valid YAML dictionary."""
+        value_str = '{"name": "test", "value": 123}'
+        result = _yaml_from_value_param(value_str)
+        assert result == {"name": "test", "value": 123}
+
+    def test_valid_yaml_list(self):
+        """Test parsing a valid YAML list."""
+        value_str = '[{"name": "item1"}, {"name": "item2"}]'
+        result = _yaml_from_value_param(value_str)
+        assert result == [{"name": "item1"}, {"name": "item2"}]
+
+    def test_complex_nested_structure(self):
+        """Test parsing a complex nested YAML structure."""
+        value_str = dedent(
+            """\
+            {
+              "tasks": [
+                {
+                  "name": "test-task",
+                  "params": [
+                    {"name": "param1", "value": "value1"}
+                  ]
+                }
+              ]
+            }
+            """
+        )
+        result = _yaml_from_value_param(value_str)
+        expected = {
+            "tasks": [{"name": "test-task", "params": [{"name": "param1", "value": "value1"}]}]
+        }
+        assert result == expected
+
+    def test_invalid_value_not_dict_or_list(self):
+        """Test error when value is not a dict or list."""
+        value_str = '"just_a_string"'
+        with pytest.raises(ValueError, match="Value parameter must be YAML sequence or map"):
+            _yaml_from_value_param(value_str)
+
+    def test_invalid_yaml_syntax(self):
+        """Test error when YAML syntax is invalid."""
+        value_str = '{"unclosed": dict'
+        with pytest.raises(Exception):  # YAML parsing error
+            _yaml_from_value_param(value_str)
+
+
+class TestModGenericInsert:
+    """Test cases for ModGenericInsert class."""
+
+    def test_initialization(self):
+        """Test operation initialization."""
+        yaml_path = ["spec", "tasks"]
+        value = {"name": "new-task"}
+        op = ModGenericInsert(yaml_path, value)
+        assert op.yaml_path == yaml_path
+        assert op.value == value
+
+    def test_insert_into_dict(self, simple_yaml_file):
+        """Test inserting new key-value pair into a dictionary."""
+        op = ModGenericInsert(["root", "level1", "config"], {"setting3": "value3"})
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: item1
+                    value: 1
+                  - name: item2
+                    value: 2
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+                  setting3: value3
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_insert_into_list(self, simple_yaml_file):
+        """Test inserting new item into a list."""
+        op = ModGenericInsert(["root", "level1", "items"], {"name": "item3", "value": 3})
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: item1
+                    value: 1
+                  - name: item2
+                    value: 2
+                  - name: item3
+                    value: 3
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_insert_into_pipeline_tasks(self, pipeline_yaml_file):
+        """Test inserting a new task into a pipeline."""
+        new_task = {
+            "name": "test",
+            "taskRef": {"name": "test-runner"},
+            "params": [{"name": "verbose", "value": "true"}],
+        }
+        op = ModGenericInsert(["spec", "tasks"], new_task)
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+
+        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                  params:
+                    - name: url
+                      value: "https://github.com/example/repo"
+                    - name: revision
+                      value: "main"
+                - name: build
+                  taskRef:
+                    name: buildah
+                  params:
+                    - name: IMAGE
+                      value: "registry.io/app:latest"
+                - name: test
+                  taskRef:
+                    name: test-runner
+                  params:
+                    - name: verbose
+                      value: 'true'
+              params:
+                - name: repo-url
+                  value: "https://github.com/default/repo"
+            """
+        )
+
+        actual = read_file_content(pipeline_yaml_file)
+        assert actual == expected
+
+    def test_validate_yaml_path_valid(self, simple_yaml_file):
+        """Test validation with a valid YAML path."""
+        op = ModGenericInsert(["root", "level1", "config"], {"new": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+
+        # Should not raise an exception
+        op.validate_yaml_path(loaded_doc)
+
+    def test_validate_yaml_path_not_found(self, simple_yaml_file):
+        """Test validation with a non-existent YAML path."""
+        op = ModGenericInsert(["root", "nonexistent", "path"], {"new": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+
+        with pytest.raises(YAMLPathNotFoundError, match="doesn't exist in the doc"):
+            op.validate_yaml_path(loaded_doc)
+
+    def test_validate_yaml_path_not_container(self, simple_yaml_file):
+        """Test validation when path points to a scalar value."""
+        op = ModGenericInsert(["root", "level1", "config", "setting1"], {"new": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+
+        with pytest.raises(RuntimeError, match="must point to sequence or map"):
+            op.validate_yaml_path(loaded_doc)
+
+    def test_handle_pipeline_run_file(self, pipeline_run_yaml_file):
+        """Test handling PipelineRun files."""
+        new_param = {"name": "new-param", "value": "new-value"}
+        op = ModGenericInsert(["spec", "pipelineSpec", "params"], new_param)
+
+        loaded_doc = load_yaml(pipeline_run_yaml_file)
+        style = YAMLStyle.detect(pipeline_run_yaml_file)
+
+        op.handle_pipeline_run_file(pipeline_run_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+                    params:
+                      - name: url
+                        value: "https://github.com/example/repo"
+                  - name: build
+                    taskRef:
+                      name: buildah
+                params:
+                  - name: global-param
+                    value: "global-value"
+                  - name: new-param
+                    value: new-value
+            """
+        )
+
+        actual = read_file_content(pipeline_run_yaml_file)
+        assert actual == expected
+
+
+class TestModGenericReplace:
+    """Test cases for ModGenericReplace class."""
+
+    def test_initialization(self):
+        """Test operation initialization."""
+        yaml_path = ["spec", "tasks", 0]
+        value = {"name": "replaced-task"}
+        op = ModGenericReplace(yaml_path, value)
+        assert op.yaml_path == yaml_path
+        assert op.value == value
+
+    def test_replace_dict_item(self, simple_yaml_file):
+        """Test replacing a dictionary item."""
+        new_config = {"setting1": "new_value1", "setting3": "value3"}
+        op = ModGenericReplace(["root", "level1", "config"], new_config)
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: item1
+                    value: 1
+                  - name: item2
+                    value: 2
+                config:
+                  setting1: new_value1
+                  setting3: value3
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_replace_list_item(self, simple_yaml_file):
+        """Test replacing a list item."""
+        new_item = {"name": "replaced-item", "value": 999}
+        op = ModGenericReplace(["root", "level1", "items", 0], new_item)
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: replaced-item
+                    value: 999
+                  - name: item2
+                    value: 2
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_replace_pipeline_task(self, pipeline_yaml_file):
+        """Test replacing a pipeline task."""
+        new_task = {
+            "name": "replaced-clone",
+            "taskRef": {"name": "git-clone-v2"},
+            "params": [{"name": "depth", "value": "1"}],
+        }
+        op = ModGenericReplace(["spec", "tasks", 0], new_task)
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+
+        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: replaced-clone
+                  taskRef:
+                    name: git-clone-v2
+                  params:
+                    - name: depth
+                      value: '1'
+                - name: build
+                  taskRef:
+                    name: buildah
+                  params:
+                    - name: IMAGE
+                      value: "registry.io/app:latest"
+              params:
+                - name: repo-url
+                  value: "https://github.com/default/repo"
+            """
+        )
+
+        actual = read_file_content(pipeline_yaml_file)
+        assert actual == expected
+
+    def test_replace_entire_list(self, simple_yaml_file):
+        """Test replacing an entire list."""
+        new_items = [{"name": "new-item1", "value": 10}, {"name": "new-item2", "value": 20}]
+        op = ModGenericReplace(["root", "level1", "items"], new_items)
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: new-item1
+                    value: 10
+                  - name: new-item2
+                    value: 20
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+
+class TestModGenericRemove:
+    """Test cases for ModGenericRemove class."""
+
+    def test_initialization(self):
+        """Test operation initialization."""
+        yaml_path = ["spec", "tasks", 0]
+        op = ModGenericRemove(yaml_path)
+        assert op.yaml_path == yaml_path
+
+    def test_remove_dict_item(self, simple_yaml_file):
+        """Test removing a dictionary item."""
+        op = ModGenericRemove(["root", "level1", "config"])
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: item1
+                    value: 1
+                  - name: item2
+                    value: 2
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_remove_list_item(self, simple_yaml_file):
+        """Test removing a list item."""
+        op = ModGenericRemove(["root", "level1", "items", 0])
+
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            root:
+              level1:
+                items:
+                  - name: item2
+                    value: 2
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+            """
+        )
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_remove_pipeline_task(self, pipeline_yaml_file):
+        """Test removing a pipeline task."""
+        op = ModGenericRemove(["spec", "tasks", 1])  # Remove build task
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+
+        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                  params:
+                    - name: url
+                      value: "https://github.com/example/repo"
+                    - name: revision
+                      value: "main"
+              params:
+                - name: repo-url
+                  value: "https://github.com/default/repo"
+            """
+        )
+
+        actual = read_file_content(pipeline_yaml_file)
+        assert actual == expected
+
+    def test_remove_nested_structure(self, pipeline_yaml_file):
+        """Test removing a nested structure."""
+        op = ModGenericRemove(["spec", "tasks", 0, "params"])
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+
+        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+
+        expected = dedent(
+            """\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+                  params:
+                    - name: IMAGE
+                      value: "registry.io/app:latest"
+              params:
+                - name: repo-url
+                  value: "https://github.com/default/repo"
+            """
+        )
+
+        actual = read_file_content(pipeline_yaml_file)
+        assert actual == expected
+
+
+class TestErrorHandling:
+    """Test error handling scenarios."""
+
+    def test_insert_invalid_path(self, simple_yaml_file):
+        """Test insert operation with invalid path."""
+        op = ModGenericInsert(["nonexistent", "path"], {"key": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        with pytest.raises(YAMLPathNotFoundError):
+            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+    def test_replace_invalid_path(self, simple_yaml_file):
+        """Test replace operation with invalid path."""
+        op = ModGenericReplace(["nonexistent", "path"], {"key": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        with pytest.raises(YAMLPathNotFoundError):
+            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+    def test_remove_invalid_path(self, simple_yaml_file):
+        """Test remove operation with invalid path."""
+        op = ModGenericRemove(["nonexistent", "path"])
+        loaded_doc = load_yaml(simple_yaml_file)
+        style = YAMLStyle.detect(simple_yaml_file)
+
+        with pytest.raises(YAMLPathNotFoundError):
+            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+
+    def test_path_to_scalar_value(self, simple_yaml_file):
+        """Test operations when path points to scalar value."""
+        op = ModGenericInsert(["root", "level1", "config", "setting1"], {"key": "value"})
+        loaded_doc = load_yaml(simple_yaml_file)
+
+        with pytest.raises(RuntimeError, match="must point to sequence or map"):
+            op.validate_yaml_path(loaded_doc)

--- a/tests/actions/modify/test_generic_cli.py
+++ b/tests/actions/modify/test_generic_cli.py
@@ -1,0 +1,651 @@
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+from pipeline_migration.cli import entry_point
+from pipeline_migration.utils import load_yaml
+
+
+class ComponentRepo:
+    def __init__(self, base_path: Path):
+        self.base_path = base_path
+        self.tekton_dir = base_path / ".tekton"
+
+
+@pytest.fixture
+def component_pipeline_dir(tmp_path):
+    """Create a temporary directory with pipeline files."""
+    component_dir = tmp_path / "component_pipeline"
+    tekton_dir = component_dir / ".tekton"
+    tekton_dir.mkdir(parents=True)
+
+    # Create pipeline file
+    pipeline_content = dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+              params:
+                - name: url
+                  value: "https://github.com/example/repo"
+                - name: revision
+                  value: "main"
+            - name: build
+              taskRef:
+                name: buildah
+              params:
+                - name: IMAGE
+                  value: "registry.io/app:latest"
+          params:
+            - name: repo-url
+              value: "https://github.com/default/repo"
+        """
+    )
+
+    pipeline_file = tekton_dir / "pipeline.yaml"
+    pipeline_file.write_text(pipeline_content)
+
+    # Create pipeline run file
+    pipeline_run_content = dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            tasks:
+              - name: clone
+                taskRef:
+                  name: git-clone
+                params:
+                  - name: url
+                    value: "https://github.com/example/repo"
+              - name: build
+                taskRef:
+                  name: buildah
+            params:
+              - name: global-param
+                value: "global-value"
+        """
+    )
+
+    pipeline_run_file = tekton_dir / "pipeline-run.yaml"
+    pipeline_run_file.write_text(pipeline_run_content)
+
+    return ComponentRepo(component_dir)
+
+
+@pytest.fixture
+def second_component_dir(tmp_path):
+    """Create a second temporary directory with different pipeline files."""
+    component_dir = tmp_path / "second_component"
+    tekton_dir = component_dir / ".tekton"
+    tekton_dir.mkdir(parents=True)
+
+    # Create a different pipeline file
+    pipeline_content = dedent(
+        """\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: another-pipeline
+        spec:
+          tasks:
+            - name: fetch-source
+              taskRef:
+                name: git-clone
+              params:
+                - name: url
+                  value: "https://github.com/another/repo"
+            - name: compile
+              taskRef:
+                name: maven
+              params:
+                - name: GOALS
+                  value: "clean compile"
+          workspaces:
+            - name: source
+        """
+    )
+
+    pipeline_file = tekton_dir / "build.yaml"
+    pipeline_file.write_text(pipeline_content)
+
+    return ComponentRepo(component_dir)
+
+
+def verify_yaml_path_exists(file_path: Path, yaml_path: list, expected_value: Any = None):
+    """Helper function to verify a YAML path exists and optionally has a specific value."""
+    doc = load_yaml(file_path)
+
+    current = doc
+    for path_element in yaml_path:
+        assert path_element in current or (
+            isinstance(current, list) and path_element < len(current)
+        ), f"Path element {path_element} not found in {file_path}"
+        current = current[path_element]
+
+    if expected_value is not None:
+        assert (
+            current == expected_value
+        ), f"Value at path {yaml_path} is {current}, expected {expected_value}"
+
+
+def verify_yaml_path_not_exists(file_path: Path, yaml_path: list):
+    """Helper function to verify a YAML path does not exist."""
+    doc = load_yaml(file_path)
+
+    current = doc
+    for _, path_element in enumerate(yaml_path):
+        if isinstance(current, dict) and path_element not in current:
+            return  # Path doesn't exist, as expected
+        elif isinstance(current, list) and path_element >= len(current):
+            return  # Index out of bounds, path doesn't exist
+        elif path_element not in current:
+            return  # Path doesn't exist
+        current = current[path_element]
+
+    # If we get here, the path exists when it shouldn't
+    assert False, f"Path {yaml_path} still exists in {file_path}"
+
+
+class TestModifyGenericInsert:
+    """Test cases for the modify generic insert CLI command."""
+
+    def test_insert_into_dict(self, component_pipeline_dir, monkeypatch):
+        """Test inserting a new key-value pair into a dictionary."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["metadata"]',
+            '{"labels": {"app": "test"}}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_yaml_path_exists(yaml_file, ["metadata", "labels"], {"app": "test"})
+
+    def test_insert_into_list(self, component_pipeline_dir, monkeypatch):
+        """Test inserting a new item into a list."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["spec", "tasks"]',
+            '{"name": "test", "taskRef": {"name": "test-runner"}}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        tasks = doc["spec"]["tasks"]
+        assert len(tasks) == 3
+        assert tasks[2]["name"] == "test"
+
+    def test_insert_complex_nested_structure(self, component_pipeline_dir, monkeypatch):
+        """Test inserting a complex nested structure."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["spec"]',
+            '{"workspaces": [{"name": "source", "description": "Source workspace"}]}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        verify_yaml_path_exists(
+            pipeline_file,
+            ["spec", "workspaces"],
+            [{"name": "source", "description": "Source workspace"}],
+        )
+
+    def test_insert_into_specific_file(self, component_pipeline_dir, monkeypatch):
+        """Test inserting into a specific file."""
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(pipeline_file),
+            "generic",
+            "insert",
+            '["spec", "params"]',
+            '{"name": "new-param", "value": "new-value"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        doc = load_yaml(pipeline_file)
+        params = doc["spec"]["params"]
+        assert len(params) == 2
+        assert params[1] == {"name": "new-param", "value": "new-value"}
+
+    def test_insert_with_multiple_directories(
+        self, component_pipeline_dir, second_component_dir, monkeypatch
+    ):
+        """Test inserting across multiple directories."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "--file-or-dir",
+            str(second_component_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["metadata"]',
+            '{"annotations": {"test": "annotation"}}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for repo in [component_pipeline_dir, second_component_dir]:
+            for yaml_file in repo.tekton_dir.glob("*.yaml"):
+                verify_yaml_path_exists(
+                    yaml_file, ["metadata", "annotations"], {"test": "annotation"}
+                )
+
+    def test_use_relative_tekton_dir(self, component_pipeline_dir, monkeypatch):
+        """Test using the default .tekton directory."""
+        # Change to the component directory
+        monkeypatch.chdir(str(component_pipeline_dir.base_path))
+
+        cmd = ["pmt", "modify", "generic", "insert", '["spec"]', '{"description": "Test pipeline"}']
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_yaml_path_exists(yaml_file, ["spec", "description"], "Test pipeline")
+
+
+class TestModifyGenericReplace:
+    """Test cases for the modify generic replace CLI command."""
+
+    def test_replace_dict_value(self, component_pipeline_dir, monkeypatch):
+        """Test replacing a dictionary value."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "replace",
+            '["spec", "params", 0]',
+            '{"name": "new-param", "value": "new-value"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        verify_yaml_path_exists(
+            pipeline_file, ["spec", "params", 0], {"name": "new-param", "value": "new-value"}
+        )
+
+    def test_replace_list_item(self, component_pipeline_dir, monkeypatch):
+        """Test replacing a list item."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "replace",
+            '["spec", "tasks", 0]',
+            '{"name": "replaced-clone", "taskRef": {"name": "git-clone-v2"}}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        first_task = doc["spec"]["tasks"][0]
+        assert first_task["name"] == "replaced-clone"
+        assert first_task["taskRef"]["name"] == "git-clone-v2"
+        assert "params" not in first_task  # Old params should be gone
+
+    def test_replace_entire_structure(self, component_pipeline_dir, monkeypatch):
+        """Test replacing an entire structure."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "replace",
+            '["spec", "params"]',
+            '[{"name": "new-param", "value": "new-value"}]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        verify_yaml_path_exists(
+            pipeline_file, ["spec", "params"], [{"name": "new-param", "value": "new-value"}]
+        )
+
+    def test_replace_nested_item(self, component_pipeline_dir, monkeypatch):
+        """Test replacing a nested item."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "replace",
+            '["spec", "tasks", 0, "taskRef"]',
+            '{"name": "git-clone-v3", "kind": "Task"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        verify_yaml_path_exists(
+            pipeline_file, ["spec", "tasks", 0, "taskRef"], {"name": "git-clone-v3", "kind": "Task"}
+        )
+
+
+class TestModifyGenericRemove:
+    """Test cases for the modify generic remove CLI command."""
+
+    def test_remove_dict_key(self, component_pipeline_dir, monkeypatch):
+        """Test removing a dictionary key."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "remove",
+            '["spec", "params"]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        verify_yaml_path_not_exists(pipeline_file, ["spec", "params"])
+
+    def test_remove_list_item(self, component_pipeline_dir, monkeypatch):
+        """Test removing a list item."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "remove",
+            '["spec", "tasks", 1]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        tasks = doc["spec"]["tasks"]
+        assert len(tasks) == 1
+        assert tasks[0]["name"] == "clone"  # Only clone task should remain
+
+    def test_remove_nested_structure(self, component_pipeline_dir, monkeypatch):
+        """Test removing a nested structure."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "remove",
+            '["spec", "tasks", 0, "params"]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        clone_task = doc["spec"]["tasks"][0]
+        assert "params" not in clone_task
+        assert clone_task["name"] == "clone"  # Task should still exist
+
+    def test_remove_from_pipeline_run(self, component_pipeline_dir, monkeypatch):
+        """Test removing from a PipelineRun file."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "remove",
+            '["spec", "pipelineSpec", "params"]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_run_file = component_pipeline_dir.tekton_dir / "pipeline-run.yaml"
+        verify_yaml_path_not_exists(pipeline_run_file, ["spec", "pipelineSpec", "params"])
+
+    def test_remove_from_multiple_files(
+        self, component_pipeline_dir, second_component_dir, monkeypatch
+    ):
+        """Test removing from multiple files."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "--file-or-dir",
+            str(second_component_dir.tekton_dir),
+            "generic",
+            "remove",
+            '["spec", "workspaces"]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        second_file = second_component_dir.tekton_dir / "build.yaml"
+        verify_yaml_path_not_exists(second_file, ["spec", "workspaces"])
+
+
+class TestModifyGenericErrorHandling:
+    """Test error handling and edge cases."""
+
+    def test_missing_yaml_path_argument(self, monkeypatch):
+        """Test that missing YAML path argument is handled."""
+        cmd = ["pmt", "modify", "generic", "insert"]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_missing_value_argument_for_insert(self, monkeypatch):
+        """Test that missing value argument for insert is handled."""
+        cmd = ["pmt", "modify", "generic", "insert", '["path"]']
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_invalid_yaml_path_format(self, component_pipeline_dir, monkeypatch):
+        """Test handling of invalid YAML path format."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '"not_a_list"',  # Invalid path format
+            '{"key": "value"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_invalid_value_format(self, component_pipeline_dir, monkeypatch):
+        """Test handling of invalid value format."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["spec"]',
+            '"just_a_string"',  # Invalid value format (not dict or list)
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_nonexistent_file_path(self, monkeypatch):
+        """Test handling of nonexistent file paths."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            "/nonexistent/path",
+            "generic",
+            "insert",
+            '["spec"]',
+            '{"key": "value"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        # Should handle gracefully (may not find any files to process)
+        entry_point()  # Should not crash
+
+    def test_nonexistent_yaml_path(self, component_pipeline_dir, monkeypatch, caplog):
+        """Test handling when YAML path doesn't exist in file."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "insert",
+            '["nonexistent", "path"]',
+            '{"key": "value"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        # Should log warnings about skipped files
+        assert "Skipped file" in caplog.text
+        assert "doesn't exist in the doc" in caplog.text
+
+    def test_invalid_subcommand(self, monkeypatch):
+        """Test that invalid subcommands are handled."""
+        cmd = ["pmt", "modify", "generic", "invalid-command"]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+
+class TestModifyGenericYQIntegration:
+    """Test integration with yq-style path expressions."""
+
+    def test_yq_style_path_simple(self, component_pipeline_dir, monkeypatch):
+        """Test using a yq-style path expression."""
+        # This simulates what you'd get from: yq '.spec.tasks[0] | path'
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "replace",
+            dedent(
+                """\
+                - spec
+                - tasks
+                - 0
+                """
+            ),
+            '{"name": "yq-replaced", "taskRef": {"name": "yq-task"}}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        # Verify replacement
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        first_task = doc["spec"]["tasks"][0]
+        assert first_task["name"] == "yq-replaced"
+
+    def test_complex_yq_path(self, component_pipeline_dir, monkeypatch):
+        """Test using a complex yq-style path."""
+        # Remove a specific parameter from a specific task
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "generic",
+            "remove",
+            dedent(
+                """\
+                - spec
+                - tasks
+                - 0
+                - params
+                - 1
+                """
+            ),  # Remove revision param
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        # Verify removal
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        clone_task = doc["spec"]["tasks"][0]
+        params = clone_task["params"]
+        assert len(params) == 1
+        assert params[0]["name"] == "url"  # Only url param should remain


### PR DESCRIPTION
This subcommand allows raw yaml operations: insert, replace, remove using the pmt's yamleditor library, ensuring that changes are minimal.

There are no semantic validations, use resource specific subcommands for semantic validation, generic subcommand should be used as the last resort option when there is no resource specific subcommand.

YAML path option, is path defined as a yaml sequence with items as index values, for example `["spec", "tasks", 17]`

yq path function can be used to determine exact YAML path (Ensure that only single path is returned)

Example of task removal:
```
pmt modify \\
  -f .tekton/pr.yaml \\
  generic remove \\
  "$(yq '.spec.pipelineSpec.tasks[] | select(.name == "prefetch-dependencies") | \\
     path' .tekton/pr.yaml)"
```