### PR TITLE
Auto-switch to MigrationImagesResolver

### DIFF
--- a/src/pipeline_migration/actions/migrate.py
+++ b/src/pipeline_migration/actions/migrate.py
@@ -862,12 +862,12 @@ def has_migration_image(image_repo: str) -> bool:
         is returned.
     """
     c = Container(image_repo)
-    limit = 10
+    tags_count = 10
     tags_iter = list_active_repo_tags(
-        c, tag_name_pattern=MIGRATION_IMAGE_TAG_LIKE_PATTERN, limit=limit
+        c, tag_name_pattern=MIGRATION_IMAGE_TAG_LIKE_PATTERN, per_page=tags_count
     )
     results: list[bool] = []
-    for i in range(limit):
+    for i in range(tags_count):
         try:
             tag_name = next(tags_iter)["name"]
             results.append(MigrationImageTag.parse(tag_name) is not None)

--- a/src/pipeline_migration/actions/migrate.py
+++ b/src/pipeline_migration/actions/migrate.py
@@ -589,6 +589,10 @@ class Resolver(ABC):
         # Migrations must be applied in the reverse order.
         bundle_upgrade.migrations.reverse()
 
+    def resolve_single_upgrade(self, bundle_upgrade: TaskBundleUpgrade) -> None:
+        """This is used by resolver proxy"""
+        return self._resolve_task(bundle_upgrade)
+
     def resolve(self, tb_upgrades: list[TaskBundleUpgrade]) -> None:
         """Resolve migrations for given task bundles upgrades
 
@@ -842,6 +846,62 @@ class MigrationImagesResolver(Resolver):
             bundle_upgrade.migrations.append(tb_migration)
 
 
+def has_migration_image(image_repo: str) -> bool:
+    """Guess if an image repository has migration images
+
+    During the transition to decentralized task repositories, not all tasks are built by the tekton
+    bundle builder pipeline and released via release pipeline. This method guesses whether a
+    repository has at least one migration image tag.
+
+    Tags are queried by a pattern that has fixed prefix ``migration-``. Although Quay does SQL LIKE
+    to match tag names, it should be good enough to get existing migration image tags if there is.
+
+    :param image_repo: bundle repository.
+    :type image_repo: str
+    :return: True if migration image tags are retrieved from the given repository. Otherwise, False
+        is returned.
+    """
+    c = Container(image_repo)
+    limit = 10
+    tags_iter = list_active_repo_tags(
+        c, tag_name_pattern=MIGRATION_IMAGE_TAG_LIKE_PATTERN, limit=limit
+    )
+    results: list[bool] = []
+    for i in range(limit):
+        try:
+            tag_name = next(tags_iter)["name"]
+            results.append(MigrationImageTag.parse(tag_name) is not None)
+        except StopIteration:
+            break
+    return any(results)
+
+
+class DecentralizationTransitionResolverProxy(Resolver):
+
+    def __init__(self):
+        self.logger = logging.getLogger("migrate.resolver-proxy")
+        self._lmr = LinkedMigrationsResolver()
+        self._mir = MigrationImagesResolver()
+
+    def _resolve_migrations(
+        self, bundle_upgrade: TaskBundleUpgrade, upgrades_range: list[QuayTagInfo]
+    ) -> Generator[TaskBundleMigration, Any, None]:
+        """This method is useless for proxy"""
+        yield TaskBundleMigration("", "")  # yield empty instance to fulfill linters
+
+    def _resolve_task(self, bundle_upgrade: TaskBundleUpgrade) -> None:
+        if has_migration_image(bundle_upgrade.dep_name):
+            resolve_method = self._mir.resolve_single_upgrade
+        else:
+            resolve_method = self._lmr.resolve_single_upgrade
+        self.logger.debug(
+            "Migration image is found from repository %s, then use %s to resolve migrations.",
+            bundle_upgrade.dep_name,
+            resolve_method.__self__.__class__.__name__,
+        )
+        resolve_method(bundle_upgrade)
+
+
 def comes_from_konflux(image_repo: str) -> bool:
     if os.environ.get("PMT_LOCAL_TEST"):
         logger.warning(
@@ -965,7 +1025,7 @@ def action(args) -> None:
     if args.use_legacy_resolver:
         resolver_class = SimpleIterationResolver
     else:
-        resolver_class = LinkedMigrationsResolver
+        resolver_class = DecentralizationTransitionResolverProxy
 
     if args.upgrades_file:
         upgrades_data = args.upgrades_file.read_text().strip()

--- a/src/pipeline_migration/quay.py
+++ b/src/pipeline_migration/quay.py
@@ -23,7 +23,7 @@ class QuayTagInfo:
 
 
 def list_active_repo_tags(
-    c: Container, tag_name: str = "", tag_name_pattern: str = "", limit: int = 0
+    c: Container, tag_name: str = "", tag_name_pattern: str = "", per_page: int = 0
 ) -> Generator[dict, Any, None]:
     """List repository tags
 
@@ -39,8 +39,8 @@ def list_active_repo_tags(
             params["specificTag"] = tag_name
         if tag_name_pattern:
             params["filter_tag_name"] = f"like:{tag_name_pattern}"
-        if limit > 0:
-            params["limit"] = str(limit)
+        if per_page > 0:
+            params["limit"] = str(per_page)
         api_url = f"https://{c.registry}/api/v1/repository/{c.namespace}/{c.repository}/tag/"
         resp = requests.get(api_url, params=params)
         resp.raise_for_status()

--- a/src/pipeline_migration/quay.py
+++ b/src/pipeline_migration/quay.py
@@ -23,7 +23,7 @@ class QuayTagInfo:
 
 
 def list_active_repo_tags(
-    c: Container, tag_name: str = "", tag_name_pattern: str = ""
+    c: Container, tag_name: str = "", tag_name_pattern: str = "", limit: int = 0
 ) -> Generator[dict, Any, None]:
     """List repository tags
 
@@ -39,6 +39,8 @@ def list_active_repo_tags(
             params["specificTag"] = tag_name
         if tag_name_pattern:
             params["filter_tag_name"] = f"like:{tag_name_pattern}"
+        if limit > 0:
+            params["limit"] = str(limit)
         api_url = f"https://{c.registry}/api/v1/repository/{c.namespace}/{c.repository}/tag/"
         resp = requests.get(api_url, params=params)
         resp.raise_for_status()


### PR DESCRIPTION
STONEBLD-3776

LinkedMigrationsResolver is working for migrations pushed by
build-definitions CI. During the transition to decentralized task
repositories, more and more tasks are started to be built by tekton
bundle builder pipeline and the others are still built by
build-definitions CI. So, the root problem here is migrations of every
bundle upgrade should be discovered and fetched by a specific resolver.

This commit introduces a resolver proxy. It selects
MigrationImagesResolver for the decentralized bundles, and
LinkedMigrationsResolver for the others.

It is an auto-switch. The condition is whether a migration image tag is
present in a bundle's image repository. If such tag is not present, it
may mean either there is actually no migrations yet for a decentralized
task, or the task is not decentralized yet. As a result,
LinkedMigrationsResolver may run for the former case. This could be
confused, but it is not a big problem, as no migration will be
discovered obviously.

When to drop the resolver proxy?

Resolver proxy and the related changes in this commit can be removed
once the decentralization transition is fully complete.

Based on #61 