### PR TITLE
Refine venv management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,31 @@
-.PHONY: compile/requirements
-compile/requirements:
-	pip-compile --generate-hashes --output-file=requirements.txt pyproject.toml
-	pip-compile --extra=test --generate-hashes --output-file=requirements-test.txt pyproject.toml
+define compile_deps
+	pip-compile --generate-hashes $(1) --output-file=requirements.txt pyproject.toml
+	pip-compile --extra=test --generate-hashes $(1) --output-file=requirements-test.txt pyproject.toml
 	# Period is converted to dash during pip-compile. This is a workaround by reverting it back
 	# so that Renovate can include the updates correctly for ruamel.yaml package.
 	for req_file in requirements.txt requirements-test.txt; do \
 		sed -i "s/ruamel-yaml-clib/ruamel.yaml.clib/" $$req_file; \
 		sed -i "s/ruamel-yaml/ruamel.yaml/" $$req_file; \
 	done
+endef
+
+.PHONY: deps/compile deps/upgrade
+
+deps/compile:
+	$(call compile_deps)
+
+deps/upgrade:
+	$(call compile_deps,--upgrade)
+
+
+.PHONY: venv/create venv/remove venv/recreate
+
+venv/create:
+	python3.12 -m venv --upgrade-deps .venv
+	.venv/bin/python3 -m pip install -r requirements-test.txt
+	.venv/bin/python3 -m pip install pip-tools
+
+venv/remove:
+	rm -rf .venv
+
+venv/recreate: venv/remove venv/create

--- a/README.md
+++ b/README.md
@@ -167,12 +167,33 @@ start:
   - item: test
 ```
 
+## Development environment management
+
+* Create a virtual environment: `make venv/create`
+* Re-create the virtual environment: `make venv/recreate`
+* Update requirements after adding dependencies:
+  ```bash
+  source .venv/bin/activate
+  make deps/compile
+  ```
+* Upgrade dependencies:
+  ```bash
+  source .venv/bin/activate
+  make deps/upgrade
+  ```
+
+> [!NOTE]
+> If you create a virtual environment by yourself, please ensure create it with
+> python3.12 explicitly: `python3.12 -m venv .venv`
+>
+> When contributing dependency changes, open pull requests for adding and
+> upgrading dependencies separately.
+
 ## Run tests
 
 ```bash
-python3 -m venv venv
-source ./venv/bin/activate
-python3 -m pip install -r requirements-test.txt
+make venv/create
+source .venv/bin/activate
 tox
 ```
 


### PR DESCRIPTION
Motivation: pip-compile running with python3.13 generates requirements without including packages that are only required for <=python3.12, that will cause failure happening to py312 testenv creation.

An example package is ruamel.yaml.clib, that is required by recent ruamel.yaml releases as of this commit:

    platform_python_implementation=="CPython" and python_version<"3.14"

As Python 3.12 is the minimum version to work with, this commit refines the Makefile to create a virtual environment with Python 3.12 and run pip-compile from inside it.

It also refactors dependency targets for add and upgrade separately.

Signed-off-by Chenxiong Qi <cqi@redhat.com>