### PR TITLE
feat: add modify pipeline subcommand for pipeline parameters

### DIFF
--- a/src/pipeline_migration/actions/modify/__init__.py
+++ b/src/pipeline_migration/actions/modify/__init__.py
@@ -3,6 +3,7 @@ from typing import Final
 
 from pipeline_migration.actions.modify.task import register_cli as register_mod_task_cli
 from pipeline_migration.actions.modify.generic import register_cli as register_mod_generic_cli
+from pipeline_migration.actions.modify.pipeline import register_cli as register_mod_pipeline_cli
 
 SUBCMD_DESCRIPTION: Final = """\
 Allows to modify existing resources in Konflux pipelines/pipeline runs.
@@ -34,3 +35,4 @@ def register_cli(subparser) -> None:
     )
     register_mod_task_cli(subparser_modify)
     register_mod_generic_cli(subparser_modify)
+    register_mod_pipeline_cli(subparser_modify)

--- a/src/pipeline_migration/actions/modify/pipeline.py
+++ b/src/pipeline_migration/actions/modify/pipeline.py
@@ -1,0 +1,434 @@
+import argparse
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import Any, Final, List
+
+from pipeline_migration.yamleditor import EditYAMLEntry, YAMLPath
+from pipeline_migration.types import FilePath
+from pipeline_migration.utils import YAMLStyle
+from pipeline_migration.pipeline import PipelineFileOperation, iterate_files_or_dirs
+
+logger = logging.getLogger("modify.pipeline")
+
+
+SUBCMD_DESCRIPTION: Final = """\
+The following are several examples of pipeline parameter modifications:
+
+* Add a pipeline parameter within relative .tekton/ directory.
+
+    cd /path/to/repo
+    pmt modify pipeline add-param my-param
+
+* Add a pipeline parameter with a default value:
+
+    pmt modify pipeline add-param my-param --default my-value
+
+* Add a pipeline parameter with a default value and type:
+
+    pmt modify pipeline add-param my-param --default my-value --type string
+
+* Add a pipeline parameter with array type and multiple default values:
+
+    pmt modify pipeline add-param my-param --type array --default val1 val2
+
+* Update an existing pipeline parameter's default value:
+
+    pmt modify pipeline update-param my-param --default new-value
+
+* Remove a pipeline parameter:
+
+    pmt modify pipeline remove-param my-param
+
+* Modify pipeline parameters in specific files:
+
+    pmt modify \\
+        -f /path/to/repo1/.tekton/pr.yaml -f /path/to/repo2/.tekton/push.yaml \\
+        pipeline add-param my-param --default my-value
+
+* Supported pipeline modifications:
+   - add-param: adds a new param to the pipeline (or updates existing)
+   - update-param: updates an existing param's default value
+   - remove-param: removes the specified param from the pipeline
+"""
+
+
+class ParamType(Enum):
+    string = "string"
+    array = "array"
+
+    def __str__(self):
+        return self.value
+
+
+def register_cli(subparser) -> None:
+    mod_pipeline_parser = subparser.add_parser(
+        "pipeline",
+        help="Modify pipeline-level parameters",
+        description=SUBCMD_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    subparser_mod = mod_pipeline_parser.add_subparsers(
+        title="subcommands to modify pipeline parameters", required=True
+    )
+
+    # add-param
+    subparser_add_param = subparser_mod.add_parser(
+        "add-param",
+        help="Add a pipeline parameter. If parameter already exists, " "it updates the value.",
+    )
+    subparser_add_param.add_argument("param_name", help="parameter name", metavar="PARAM-NAME")
+    subparser_add_param.add_argument(
+        "--default",
+        dest="param_default",
+        nargs="+",
+        help="default value(s) for the parameter",
+        metavar="DEFAULT",
+    )
+    subparser_add_param.add_argument(
+        "-t",
+        "--type",
+        dest="param_type",
+        help="parameter type (Default: %(default)s)",
+        type=ParamType,
+        choices=list(ParamType),
+        default=None,
+    )
+    subparser_add_param.set_defaults(action=action_add_param)
+
+    # update-param
+    subparser_update_param = subparser_mod.add_parser(
+        "update-param",
+        help="Update an existing pipeline parameter's default value.",
+    )
+    subparser_update_param.add_argument("param_name", help="parameter name", metavar="PARAM-NAME")
+    subparser_update_param.add_argument(
+        "--default",
+        dest="param_default",
+        nargs="+",
+        required=True,
+        help="new default value(s) for the parameter",
+        metavar="DEFAULT",
+    )
+    subparser_update_param.set_defaults(action=action_update_param)
+
+    # remove-param
+    subparser_remove_param = subparser_mod.add_parser(
+        "remove-param",
+        help="Remove the specified parameter from the pipeline.",
+    )
+    subparser_remove_param.add_argument("param_name", help="parameter name", metavar="PARAM-NAME")
+    subparser_remove_param.set_defaults(action=action_remove_param)
+
+
+class PipelineParamBase(PipelineFileOperation):
+
+    def __init__(self):
+        super().__init__()
+
+    def _get_params_paths(self, kind: str) -> list[YAMLPath]:
+        if kind == "Pipeline":
+            return [["spec", "params"]]
+        else:
+            return [["spec", "pipelineSpec", "params"]]
+
+    def _get_params_parent_paths(self, kind: str) -> list[YAMLPath]:
+        if kind == "Pipeline":
+            return [["spec"]]
+        else:
+            return [["spec", "pipelineSpec"]]
+
+    def _find_param_index(self, params: list, param_name: str) -> int | None:
+        for index, param in enumerate(params):
+            if param.get("name") == param_name:
+                return index
+        return None
+
+    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        self._handle(file_path, loaded_doc, style, "Pipeline")
+
+    def handle_pipeline_run_file(
+        self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle
+    ) -> None:
+        self._handle(file_path, loaded_doc, style, "PipelineRun")
+
+    def _handle(
+        self,
+        file_path: FilePath,
+        loaded_doc: Any,
+        style: YAMLStyle,
+        kind: str,
+    ) -> None:
+        raise NotImplementedError
+
+
+class AddPipelineParamOperation(PipelineParamBase):
+    def __init__(
+        self,
+        param_name: str,
+        param_default: str | List[str] | None = None,
+        param_type: ParamType | None = None,
+    ) -> None:
+        super().__init__()
+        self.param_name = param_name
+        self.param_default = param_default
+        self.param_type = param_type
+
+    def _build_param_data(self) -> dict:
+        data: dict[str, Any] = {"name": self.param_name}
+        if self.param_type is not None:
+            data["type"] = str(self.param_type)
+        if self.param_default is not None:
+            data["default"] = self.param_default
+        return data
+
+    def _handle(
+        self,
+        file_path: FilePath,
+        loaded_doc: Any,
+        style: YAMLStyle,
+        kind: str,
+    ) -> None:
+        params_paths = self._get_params_paths(kind)
+        parent_paths = self._get_params_parent_paths(kind)
+
+        for params_path, parent_path in zip(params_paths, parent_paths):
+            try:
+                parent = loaded_doc
+                for key in parent_path:
+                    parent = parent[key]
+            except KeyError:
+                continue
+
+            if "params" not in parent:
+                new_data = {"params": [self._build_param_data()]}
+                logger.info(
+                    "pipeline in '%s': param '%s' will be created "
+                    "(params section will be created)",
+                    file_path,
+                    self.param_name,
+                )
+                yamledit = EditYAMLEntry(file_path, style=style)
+                yamledit.insert(parent_path, new_data)
+                return
+
+            params = parent["params"]
+            param_index = self._find_param_index(params, self.param_name)
+
+            if param_index is not None:
+                existing_param = params[param_index]
+                new_data = self._build_param_data()
+
+                if self._param_matches(existing_param, new_data):
+                    logger.info(
+                        "pipeline in '%s': param '%s' already has required values",
+                        file_path,
+                        self.param_name,
+                    )
+                    return
+
+                logger.info(
+                    "pipeline in '%s': param '%s' will be updated",
+                    file_path,
+                    self.param_name,
+                )
+                path = list(params_path) + [param_index]
+                yamledit = EditYAMLEntry(file_path, style=style)
+                yamledit.replace(path, new_data)
+                return
+
+            logger.info(
+                "pipeline in '%s': param '%s' will be created",
+                file_path,
+                self.param_name,
+            )
+            yamledit = EditYAMLEntry(file_path, style=style)
+            yamledit.insert(params_path, self._build_param_data())
+
+    def _param_matches(self, existing: dict, new: dict) -> bool:
+        for key in ("name", "type", "default"):
+            existing_val = existing.get(key)
+            new_val = new.get(key)
+            if isinstance(existing_val, list) and isinstance(new_val, list):
+                if set(existing_val) != set(new_val):
+                    return False
+            elif existing_val != new_val:
+                return False
+        return True
+
+
+class UpdatePipelineParamOperation(PipelineParamBase):
+    def __init__(
+        self,
+        param_name: str,
+        param_default: str | List[str],
+    ) -> None:
+        super().__init__()
+        self.param_name = param_name
+        self.param_default = param_default
+
+    def _handle(
+        self,
+        file_path: FilePath,
+        loaded_doc: Any,
+        style: YAMLStyle,
+        kind: str,
+    ) -> None:
+        params_paths = self._get_params_paths(kind)
+        parent_paths = self._get_params_parent_paths(kind)
+
+        for params_path, parent_path in zip(params_paths, parent_paths):
+            try:
+                parent = loaded_doc
+                for key in parent_path:
+                    parent = parent[key]
+            except KeyError:
+                continue
+
+            if "params" not in parent:
+                logger.warning(
+                    "pipeline in '%s': no params section, nothing to update",
+                    file_path,
+                )
+                return
+
+            params = parent["params"]
+            param_index = self._find_param_index(params, self.param_name)
+
+            if param_index is None:
+                logger.warning(
+                    "pipeline in '%s': param '%s' does not exist, nothing to update",
+                    file_path,
+                    self.param_name,
+                )
+                return
+
+            existing_param = params[param_index]
+            existing_default = existing_param.get("default")
+
+            if isinstance(existing_default, list) and isinstance(self.param_default, list):
+                if set(existing_default) == set(self.param_default):
+                    logger.info(
+                        "pipeline in '%s': param '%s' already has required default",
+                        file_path,
+                        self.param_name,
+                    )
+                    return
+            elif existing_default == self.param_default:
+                logger.info(
+                    "pipeline in '%s': param '%s' already has required default",
+                    file_path,
+                    self.param_name,
+                )
+                return
+
+            new_data = dict(existing_param)
+            new_data["default"] = self.param_default
+
+            logger.info(
+                "pipeline in '%s': param '%s' default will be updated",
+                file_path,
+                self.param_name,
+            )
+            path = list(params_path) + [param_index]
+            yamledit = EditYAMLEntry(file_path, style=style)
+            yamledit.replace(path, new_data)
+
+
+class RemovePipelineParamOperation(PipelineParamBase):
+    def __init__(self, param_name: str) -> None:
+        super().__init__()
+        self.param_name = param_name
+
+    def _handle(
+        self,
+        file_path: FilePath,
+        loaded_doc: Any,
+        style: YAMLStyle,
+        kind: str,
+    ) -> None:
+        params_paths = self._get_params_paths(kind)
+        parent_paths = self._get_params_parent_paths(kind)
+
+        for params_path, parent_path in zip(params_paths, parent_paths):
+            try:
+                parent = loaded_doc
+                for key in parent_path:
+                    parent = parent[key]
+            except KeyError:
+                continue
+
+            if "params" not in parent:
+                logger.info(
+                    "pipeline in '%s': no params section, nothing to remove",
+                    file_path,
+                )
+                return
+
+            params = parent["params"]
+            param_index = self._find_param_index(params, self.param_name)
+
+            if param_index is None:
+                logger.info(
+                    "pipeline in '%s': param '%s' does not exist, nothing to remove",
+                    file_path,
+                    self.param_name,
+                )
+                return
+
+            logger.info(
+                "pipeline in '%s': param '%s' will be removed",
+                file_path,
+                self.param_name,
+            )
+            path = list(params_path) + [param_index]
+            yamledit = EditYAMLEntry(file_path, style=style)
+            yamledit.delete(path)
+
+
+def _get_search_places(args) -> list[str]:
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+    return search_places
+
+
+def _parse_default_value(args) -> str | list[str] | None:
+    if args.param_default is None:
+        return None
+    if hasattr(args, "param_type") and args.param_type == ParamType.array:
+        return args.param_default
+    if len(args.param_default) == 1:
+        return args.param_default[0]
+    return args.param_default
+
+
+def action_add_param(args) -> None:
+    default_value = _parse_default_value(args)
+    search_places = _get_search_places(args)
+
+    op = AddPipelineParamOperation(args.param_name, default_value, args.param_type)
+    for file_path in iterate_files_or_dirs(search_places):
+        op.handle(str(file_path))
+
+
+def action_update_param(args) -> None:
+    default_value = args.param_default
+    if len(default_value) == 1:
+        default_value = default_value[0]
+
+    search_places = _get_search_places(args)
+
+    op = UpdatePipelineParamOperation(args.param_name, default_value)
+    for file_path in iterate_files_or_dirs(search_places):
+        op.handle(str(file_path))
+
+
+def action_remove_param(args) -> None:
+    search_places = _get_search_places(args)
+
+    op = RemovePipelineParamOperation(args.param_name)
+    for file_path in iterate_files_or_dirs(search_places):
+        op.handle(str(file_path))

--- a/tests/actions/modify/test_pipeline.py
+++ b/tests/actions/modify/test_pipeline.py
@@ -1,0 +1,682 @@
+import pytest
+from textwrap import dedent
+
+from pipeline_migration.actions.modify.pipeline import (
+    AddPipelineParamOperation,
+    UpdatePipelineParamOperation,
+    RemovePipelineParamOperation,
+    ParamType,
+)
+from pipeline_migration.utils import load_yaml, YAMLStyle
+
+
+def read_file_content(file_path: str) -> str:
+    with open(file_path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture
+def pipeline_yaml_file(create_yaml_file):
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          params:
+            - name: git-url
+            - name: revision
+              default: "main"
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+        """)
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_no_params_yaml_file(create_yaml_file):
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+        """)
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_run_yaml_file(create_yaml_file):
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            params:
+              - name: git-url
+              - name: revision
+                default: "main"
+            tasks:
+              - name: clone
+                taskRef:
+                  name: git-clone
+        """)
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_run_no_params_yaml_file(create_yaml_file):
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            tasks:
+              - name: clone
+                taskRef:
+                  name: git-clone
+        """)
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_typed_params_yaml_file(create_yaml_file):
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          params:
+            - name: git-url
+              type: string
+              default: "https://github.com/example/repo"
+            - name: images
+              type: array
+              default:
+                - "image1"
+                - "image2"
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+        """)
+    return create_yaml_file(content)
+
+
+class TestAddPipelineParamOperation:
+
+    def test_add_param_name_only(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation("new-param")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: new-param
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_with_default(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation("new-param", param_default="my-value")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: new-param
+                  default: my-value
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_with_type(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation(
+            "new-param", param_default="my-value", param_type=ParamType.string
+        )
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: new-param
+                  type: string
+                  default: my-value
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_with_array_default(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation(
+            "images", param_default=["img1", "img2"], param_type=ParamType.array
+        )
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: images
+                  type: array
+                  default:
+                    - img1
+                    - img2
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_to_pipeline_without_params(self, pipeline_no_params_yaml_file):
+        op = AddPipelineParamOperation("new-param", param_default="value")
+        op.handle(str(pipeline_no_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+              params:
+                - name: new-param
+                  default: value
+            """)
+        assert read_file_content(pipeline_no_params_yaml_file) == expected
+
+    def test_add_param_updates_existing(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation("revision", param_default="develop")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: develop
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_no_change_when_same(self, pipeline_yaml_file):
+        op = AddPipelineParamOperation("revision", param_default="main")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_param_pipeline_run(self, pipeline_run_yaml_file):
+        op = AddPipelineParamOperation("new-param", param_default="value")
+        op.handle(str(pipeline_run_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                params:
+                  - name: git-url
+                  - name: revision
+                    default: "main"
+                  - name: new-param
+                    default: value
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+            """)
+        assert read_file_content(pipeline_run_yaml_file) == expected
+
+    def test_add_param_pipeline_run_no_params(self, pipeline_run_no_params_yaml_file):
+        op = AddPipelineParamOperation("new-param", param_default="value")
+        op.handle(str(pipeline_run_no_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+                params:
+                  - name: new-param
+                    default: value
+            """)
+        assert read_file_content(pipeline_run_no_params_yaml_file) == expected
+
+
+class TestUpdatePipelineParamOperation:
+
+    def test_update_existing_param(self, pipeline_yaml_file):
+        op = UpdatePipelineParamOperation("revision", "develop")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: develop
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_update_no_change_when_same(self, pipeline_yaml_file):
+        op = UpdatePipelineParamOperation("revision", "main")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_update_nonexistent_param(self, pipeline_yaml_file):
+        op = UpdatePipelineParamOperation("nonexistent", "value")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_update_no_params_section(self, pipeline_no_params_yaml_file):
+        op = UpdatePipelineParamOperation("nonexistent", "value")
+        op.handle(str(pipeline_no_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_no_params_yaml_file) == expected
+
+    def test_update_param_pipeline_run(self, pipeline_run_yaml_file):
+        op = UpdatePipelineParamOperation("revision", "develop")
+        op.handle(str(pipeline_run_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                params:
+                  - name: git-url
+                  - name: revision
+                    default: develop
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+            """)
+        assert read_file_content(pipeline_run_yaml_file) == expected
+
+    def test_update_preserves_type(self, pipeline_typed_params_yaml_file):
+        op = UpdatePipelineParamOperation("git-url", "https://new-url.com")
+        op.handle(str(pipeline_typed_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                  type: string
+                  default: https://new-url.com
+                - name: images
+                  type: array
+                  default:
+                    - "image1"
+                    - "image2"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_typed_params_yaml_file) == expected
+
+    def test_update_array_param(self, pipeline_typed_params_yaml_file):
+        op = UpdatePipelineParamOperation("images", ["new1", "new2", "new3"])
+        op.handle(str(pipeline_typed_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                  type: string
+                  default: "https://github.com/example/repo"
+                - name: images
+                  type: array
+                  default:
+                    - new1
+                    - new2
+                    - new3
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_typed_params_yaml_file) == expected
+
+
+class TestRemovePipelineParamOperation:
+
+    def test_remove_existing_param(self, pipeline_yaml_file):
+        op = RemovePipelineParamOperation("revision")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_remove_nonexistent_param(self, pipeline_yaml_file):
+        op = RemovePipelineParamOperation("nonexistent")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_remove_no_params_section(self, pipeline_no_params_yaml_file):
+        op = RemovePipelineParamOperation("nonexistent")
+        op.handle(str(pipeline_no_params_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_no_params_yaml_file) == expected
+
+    def test_remove_all_params(self, pipeline_yaml_file):
+        op1 = RemovePipelineParamOperation("git-url")
+        op1.handle(str(pipeline_yaml_file))
+
+        op2 = RemovePipelineParamOperation("revision")
+        op2.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_remove_param_pipeline_run(self, pipeline_run_yaml_file):
+        op = RemovePipelineParamOperation("revision")
+        op.handle(str(pipeline_run_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                params:
+                  - name: git-url
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+            """)
+        assert read_file_content(pipeline_run_yaml_file) == expected
+
+    def test_remove_first_param(self, pipeline_yaml_file):
+        op = RemovePipelineParamOperation("git-url")
+        op.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+
+class TestComplexScenarios:
+
+    def test_add_then_remove(self, pipeline_yaml_file):
+        op_add = AddPipelineParamOperation("new-param", param_default="value")
+        op_add.handle(str(pipeline_yaml_file))
+
+        op_remove = RemovePipelineParamOperation("new-param")
+        op_remove.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_add_then_update(self, pipeline_yaml_file):
+        op_add = AddPipelineParamOperation("new-param", param_default="old-value")
+        op_add.handle(str(pipeline_yaml_file))
+
+        op_update = UpdatePipelineParamOperation("new-param", "new-value")
+        op_update.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: new-param
+                  default: new-value
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected
+
+    def test_multiple_adds(self, pipeline_yaml_file):
+        op1 = AddPipelineParamOperation("param1", param_default="val1")
+        op1.handle(str(pipeline_yaml_file))
+
+        op2 = AddPipelineParamOperation("param2", param_default="val2")
+        op2.handle(str(pipeline_yaml_file))
+
+        expected = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              params:
+                - name: git-url
+                - name: revision
+                  default: "main"
+                - name: param1
+                  default: val1
+                - name: param2
+                  default: val2
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+            """)
+        assert read_file_content(pipeline_yaml_file) == expected

--- a/tests/actions/modify/test_pipeline_cli.py
+++ b/tests/actions/modify/test_pipeline_cli.py
@@ -1,0 +1,439 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from pipeline_migration.cli import entry_point
+from pipeline_migration.utils import load_yaml
+
+
+class ComponentRepo:
+    def __init__(self, base_path: Path):
+        self.base_path = base_path
+        self.tekton_dir = base_path / ".tekton"
+
+
+@pytest.fixture
+def component_pipeline_dir(tmp_path):
+    component_dir = tmp_path / "component_pipeline"
+    tekton_dir = component_dir / ".tekton"
+    tekton_dir.mkdir(parents=True)
+
+    pipeline_content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          params:
+            - name: git-url
+            - name: revision
+              default: "main"
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+        """)
+    pipeline_file = tekton_dir / "pipeline.yaml"
+    pipeline_file.write_text(pipeline_content)
+
+    pipeline_run_content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            params:
+              - name: git-url
+              - name: revision
+                default: "main"
+            tasks:
+              - name: clone
+                taskRef:
+                  name: git-clone
+        """)
+    pipeline_run_file = tekton_dir / "pipeline-run.yaml"
+    pipeline_run_file.write_text(pipeline_run_content)
+
+    return ComponentRepo(component_dir)
+
+
+@pytest.fixture
+def component_no_params_dir(tmp_path):
+    component_dir = tmp_path / "component_no_params"
+    tekton_dir = component_dir / ".tekton"
+    tekton_dir.mkdir(parents=True)
+
+    pipeline_content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clone
+              taskRef:
+                name: git-clone
+        """)
+    pipeline_file = tekton_dir / "pipeline.yaml"
+    pipeline_file.write_text(pipeline_content)
+
+    return ComponentRepo(component_dir)
+
+
+def verify_pipeline_param_exists(file_path: Path, param_name: str, default=None):
+    doc = load_yaml(file_path)
+
+    params = None
+    if doc.get("kind") == "Pipeline":
+        params = doc.get("spec", {}).get("params")
+    elif doc.get("kind") == "PipelineRun":
+        params = doc.get("spec", {}).get("pipelineSpec", {}).get("params")
+
+    assert params is not None, f"No params found in {file_path}"
+
+    param = next((p for p in params if p["name"] == param_name), None)
+    assert param is not None, f"Parameter {param_name} not found in {file_path}"
+
+    if default is not None:
+        assert (
+            param.get("default") == default
+        ), f"Parameter {param_name} has wrong default in {file_path}"
+
+
+def verify_pipeline_param_absent(file_path: Path, param_name: str):
+    doc = load_yaml(file_path)
+
+    params = None
+    if doc.get("kind") == "Pipeline":
+        params = doc.get("spec", {}).get("params")
+    elif doc.get("kind") == "PipelineRun":
+        params = doc.get("spec", {}).get("pipelineSpec", {}).get("params")
+
+    if params is None:
+        return
+
+    param = next((p for p in params if p["name"] == param_name), None)
+    assert param is None, f"Parameter {param_name} still exists in {file_path}"
+
+
+class TestCliAddParam:
+
+    def test_add_param(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "new-param",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "new-param")
+
+    def test_add_param_with_default(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "new-param",
+            "--default",
+            "my-value",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "new-param", default="my-value")
+
+    def test_add_param_with_type(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "new-param",
+            "--default",
+            "value",
+            "--type",
+            "string",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "new-param", default="value")
+
+    def test_add_param_array_type(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "images",
+            "--type",
+            "array",
+            "--default",
+            "img1",
+            "img2",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "images", default=["img1", "img2"])
+
+    def test_add_param_updates_existing(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "revision",
+            "--default",
+            "develop",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "revision", default="develop")
+
+    def test_add_param_no_params_section(self, component_no_params_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_no_params_dir.tekton_dir),
+            "pipeline",
+            "add-param",
+            "new-param",
+            "--default",
+            "value",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_no_params_dir.tekton_dir / "pipeline.yaml"
+        verify_pipeline_param_exists(pipeline_file, "new-param", default="value")
+
+    def test_add_param_relative_tekton_dir(self, component_pipeline_dir, monkeypatch):
+        monkeypatch.chdir(str(component_pipeline_dir.base_path))
+        cmd = ["pmt", "modify", "pipeline", "add-param", "new-param", "--default", "val"]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "new-param", default="val")
+
+    def test_add_param_specific_file(self, component_pipeline_dir, monkeypatch):
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(pipeline_file),
+            "pipeline",
+            "add-param",
+            "new-param",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        verify_pipeline_param_exists(pipeline_file, "new-param")
+
+
+class TestCliUpdateParam:
+
+    def test_update_param(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "update-param",
+            "revision",
+            "--default",
+            "develop",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "revision", default="develop")
+
+    def test_update_nonexistent_param(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "update-param",
+            "nonexistent",
+            "--default",
+            "value",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "git-url")
+            verify_pipeline_param_exists(yaml_file, "revision", default="main")
+
+    def test_update_requires_default(self, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "pipeline",
+            "update-param",
+            "revision",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_update_relative_tekton_dir(self, component_pipeline_dir, monkeypatch):
+        monkeypatch.chdir(str(component_pipeline_dir.base_path))
+        cmd = [
+            "pmt",
+            "modify",
+            "pipeline",
+            "update-param",
+            "revision",
+            "--default",
+            "develop",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "revision", default="develop")
+
+
+class TestCliRemoveParam:
+
+    def test_remove_param(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "remove-param",
+            "revision",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_absent(yaml_file, "revision")
+            verify_pipeline_param_exists(yaml_file, "git-url")
+
+    def test_remove_nonexistent_param(self, component_pipeline_dir, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "remove-param",
+            "nonexistent",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_exists(yaml_file, "git-url")
+            verify_pipeline_param_exists(yaml_file, "revision", default="main")
+
+    def test_remove_all_params(self, component_pipeline_dir, monkeypatch):
+        cmd1 = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "remove-param",
+            "git-url",
+        ]
+        monkeypatch.setattr("sys.argv", cmd1)
+        entry_point()
+
+        cmd2 = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "pipeline",
+            "remove-param",
+            "revision",
+        ]
+        monkeypatch.setattr("sys.argv", cmd2)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_absent(yaml_file, "git-url")
+            verify_pipeline_param_absent(yaml_file, "revision")
+
+    def test_remove_relative_tekton_dir(self, component_pipeline_dir, monkeypatch):
+        monkeypatch.chdir(str(component_pipeline_dir.base_path))
+        cmd = ["pmt", "modify", "pipeline", "remove-param", "revision"]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_pipeline_param_absent(yaml_file, "revision")
+
+
+class TestCliErrorHandling:
+
+    def test_missing_subcommand(self, monkeypatch):
+        cmd = ["pmt", "modify", "pipeline"]
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_missing_param_name(self, monkeypatch):
+        cmd = ["pmt", "modify", "pipeline", "add-param"]
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_invalid_subcommand(self, monkeypatch):
+        cmd = ["pmt", "modify", "pipeline", "invalid-command"]
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_nonexistent_file_path(self, monkeypatch):
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            "/nonexistent/path",
+            "pipeline",
+            "add-param",
+            "new-param",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()


### PR DESCRIPTION
Add `pmt modify pipeline` with add-param, update-param, and remove-param operations to manage pipeline-level parameters in Pipeline and PipelineRun YAML files.