### PR TITLE
modify generic: support more generic yaml

### DIFF
--- a/src/pipeline_migration/actions/modify/generic.py
+++ b/src/pipeline_migration/actions/modify/generic.py
@@ -7,7 +7,6 @@ from typing import Any, Final
 from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
 from pipeline_migration.yamleditor import EditYAMLEntry, YAMLPath
-from pipeline_migration.types import FilePath
 from pipeline_migration.utils import YAMLStyle, create_yaml_obj, load_yaml
 from pipeline_migration.pipeline import iterate_files_or_dirs
 
@@ -246,9 +245,9 @@ class ModGenericBase:
         doc = load_yaml(file_path, yaml_style)
         if not isinstance(doc, dict):
             raise UnsupportedYAML(f"Given file {file_path} is not a YAML mapping.")
-        self.handle_generic_operation(file_path, doc, yaml_style)
+        self.handle_generic_operation(Path(file_path), doc, yaml_style)
 
-    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: Path, loaded_doc: Any, style: YAMLStyle) -> None:
         """Override this in subclasses."""
         raise NotImplementedError
 
@@ -260,7 +259,7 @@ class ModGenericInsert(ModGenericBase):
         super().__init__(yaml_path)
         self.value = value
 
-    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: Path, loaded_doc: Any, style: YAMLStyle) -> None:
         """Insert the configured value at the YAML path in the pipeline file."""
         logger.info("Inserting content into YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc)
@@ -290,7 +289,7 @@ class ModGenericReplace(ModGenericBase):
         super().__init__(yaml_path)
         self.value = value
 
-    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: Path, loaded_doc: Any, style: YAMLStyle) -> None:
         """Replace the value at the YAML path in the pipeline file."""
         logger.info("Replacing content at YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc, allow_scalar=True)
@@ -319,7 +318,7 @@ class ModGenericRemove(ModGenericBase):
     def __init__(self, yaml_path: YAMLPath):
         super().__init__(yaml_path)
 
-    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: Path, loaded_doc: Any, style: YAMLStyle) -> None:
         """Remove the node at the YAML path in the pipeline file."""
         logger.info("Removing YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc, allow_scalar=True)

--- a/src/pipeline_migration/actions/modify/generic.py
+++ b/src/pipeline_migration/actions/modify/generic.py
@@ -8,8 +8,8 @@ from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
 from pipeline_migration.yamleditor import EditYAMLEntry, YAMLPath
 from pipeline_migration.types import FilePath
-from pipeline_migration.utils import YAMLStyle, create_yaml_obj
-from pipeline_migration.pipeline import PipelineFileOperation, iterate_files_or_dirs
+from pipeline_migration.utils import YAMLStyle, create_yaml_obj, load_yaml
+from pipeline_migration.pipeline import iterate_files_or_dirs
 
 logger = logging.getLogger("modify.generic")
 
@@ -57,6 +57,10 @@ Use resource specific subcommands if they are available instead to have a proper
 
 class YAMLPathNotFoundError(Exception):
     """Exception when given path doesn't exist in the YAML doc"""
+
+
+class UnsupportedYAML(Exception):
+    """The file to modify contains unsupported YAML."""
 
 
 def _yaml_path_from_param(yaml_path_param: str) -> YAMLPath:
@@ -209,7 +213,7 @@ def register_cli(subparser) -> None:
     subparser_remove.set_defaults(action=action_remove)
 
 
-class ModGenericBase(PipelineFileOperation):
+class ModGenericBase:
     """Base class for generic resource modifications"""
 
     def __init__(self, yaml_path: YAMLPath):
@@ -237,12 +241,16 @@ class ModGenericBase(PipelineFileOperation):
                     f"Provided YAML path {self.yaml_path} must point to sequence or map"
                 )
 
-    def handle_pipeline_run_file(
-        self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle
-    ) -> None:
-        """Handle a PipelineRun file by delegating to the Pipeline handler."""
-        # the same implementation as pipeline
-        self.handle_pipeline_file(file_path, loaded_doc, style)
+    def handle(self, file_path: str) -> None:
+        yaml_style = YAMLStyle.detect(file_path)
+        doc = load_yaml(file_path, yaml_style)
+        if not isinstance(doc, dict):
+            raise UnsupportedYAML(f"Given file {file_path} is not a YAML mapping.")
+        self.handle_generic_operation(file_path, doc, yaml_style)
+
+    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        """Override this in subclasses."""
+        raise NotImplementedError
 
 
 class ModGenericInsert(ModGenericBase):
@@ -252,7 +260,7 @@ class ModGenericInsert(ModGenericBase):
         super().__init__(yaml_path)
         self.value = value
 
-    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
         """Insert the configured value at the YAML path in the pipeline file."""
         logger.info("Inserting content into YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc)
@@ -282,7 +290,7 @@ class ModGenericReplace(ModGenericBase):
         super().__init__(yaml_path)
         self.value = value
 
-    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
         """Replace the value at the YAML path in the pipeline file."""
         logger.info("Replacing content at YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc, allow_scalar=True)
@@ -311,7 +319,7 @@ class ModGenericRemove(ModGenericBase):
     def __init__(self, yaml_path: YAMLPath):
         super().__init__(yaml_path)
 
-    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+    def handle_generic_operation(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
         """Remove the node at the YAML path in the pipeline file."""
         logger.info("Removing YAML path %s in file %s", self.yaml_path, file_path)
         self.validate_yaml_path(loaded_doc, allow_scalar=True)

--- a/tests/actions/modify/test_generic.py
+++ b/tests/actions/modify/test_generic.py
@@ -6,6 +6,7 @@ from pipeline_migration.actions.modify.generic import (
     ModGenericInsert,
     ModGenericReplace,
     ModGenericRemove,
+    UnsupportedYAML,
     YAMLPathNotFoundError,
     _yaml_path_from_param,
     _yaml_from_value_param,
@@ -216,7 +217,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -242,7 +243,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -274,7 +275,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -343,7 +344,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(pipeline_run_yaml_file)
         style = YAMLStyle.detect(pipeline_run_yaml_file)
 
-        op.handle_pipeline_run_file(pipeline_run_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_run_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -385,7 +386,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(yaml_file)
         style = YAMLStyle.detect(yaml_file)
 
-        op.handle_pipeline_file(yaml_file, loaded_doc, style)
+        op.handle_generic_operation(yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             items:
@@ -410,7 +411,7 @@ class TestModGenericInsert:
         loaded_doc = load_yaml(yaml_file)
         style = YAMLStyle.detect(yaml_file)
 
-        op.handle_pipeline_file(yaml_file, loaded_doc, style)
+        op.handle_generic_operation(yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             numbers:
@@ -436,7 +437,7 @@ class TestModGenericInsert:
         style = YAMLStyle.detect(yaml_file)
 
         with pytest.raises(ValueError, match="Only dict values can be inserted into a dict"):
-            op.handle_pipeline_file(yaml_file, loaded_doc, style)
+            op.handle_generic_operation(yaml_file, loaded_doc, style)
 
 
 class TestModGenericReplace:
@@ -458,7 +459,7 @@ class TestModGenericReplace:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -484,7 +485,7 @@ class TestModGenericReplace:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -514,7 +515,7 @@ class TestModGenericReplace:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -551,7 +552,7 @@ class TestModGenericReplace:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -576,7 +577,7 @@ class TestModGenericReplace:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -611,7 +612,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -633,7 +634,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -656,7 +657,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -688,7 +689,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -721,7 +722,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -745,7 +746,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -781,7 +782,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(simple_yaml_file)
         style = YAMLStyle.detect(simple_yaml_file)
 
-        op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             root:
@@ -805,7 +806,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -841,7 +842,7 @@ class TestModGenericRemove:
         loaded_doc = load_yaml(pipeline_yaml_file)
         style = YAMLStyle.detect(pipeline_yaml_file)
 
-        op.handle_pipeline_file(pipeline_yaml_file, loaded_doc, style)
+        op.handle_generic_operation(pipeline_yaml_file, loaded_doc, style)
 
         expected = dedent("""\
             apiVersion: tekton.dev/v1
@@ -872,6 +873,41 @@ class TestModGenericRemove:
         assert actual == expected
 
 
+class TestModGenericBaseHandle:
+    """Test cases for ModGenericBase.handle() method."""
+
+    def test_handle_non_pipeline_yaml(self, simple_yaml_file):
+        """Test that handle() works on arbitrary YAML, not just Pipeline resources."""
+        op = ModGenericInsert(["root", "level1", "config"], {"setting3": "value3"})
+
+        op.handle(str(simple_yaml_file))
+
+        expected = dedent("""\
+            root:
+              level1:
+                items:
+                  - name: item1
+                    value: 1
+                  - name: item2
+                    value: 2
+                config:
+                  setting1: "value1"
+                  setting2: "value2"
+                  setting3: value3
+            """)
+
+        actual = read_file_content(simple_yaml_file)
+        assert actual == expected
+
+    def test_handle_unsupported_yaml(self, create_yaml_file):
+        """Test that handle() raises UnsupportedYAML for non-mapping YAML."""
+        yaml_file = create_yaml_file("hello\n")
+        op = ModGenericInsert(["items"], "item3")
+
+        with pytest.raises(UnsupportedYAML, match="is not a YAML mapping"):
+            op.handle(str(yaml_file))
+
+
 class TestErrorHandling:
     """Test error handling scenarios."""
 
@@ -882,7 +918,7 @@ class TestErrorHandling:
         style = YAMLStyle.detect(simple_yaml_file)
 
         with pytest.raises(YAMLPathNotFoundError):
-            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+            op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
     def test_replace_invalid_path(self, simple_yaml_file):
         """Test replace operation with invalid path."""
@@ -891,7 +927,7 @@ class TestErrorHandling:
         style = YAMLStyle.detect(simple_yaml_file)
 
         with pytest.raises(YAMLPathNotFoundError):
-            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+            op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
     def test_remove_invalid_path(self, simple_yaml_file):
         """Test remove operation with invalid path."""
@@ -900,7 +936,7 @@ class TestErrorHandling:
         style = YAMLStyle.detect(simple_yaml_file)
 
         with pytest.raises(YAMLPathNotFoundError):
-            op.handle_pipeline_file(simple_yaml_file, loaded_doc, style)
+            op.handle_generic_operation(simple_yaml_file, loaded_doc, style)
 
     def test_path_to_scalar_value(self, simple_yaml_file):
         """Test operations when path points to scalar value."""

--- a/tests/actions/modify/test_generic_cli.py
+++ b/tests/actions/modify/test_generic_cli.py
@@ -152,6 +152,93 @@ def verify_yaml_path_not_exists(file_path: Path, yaml_path: list):
     assert False, f"Path {yaml_path} still exists in {file_path}"
 
 
+@pytest.fixture
+def plain_yaml_dir(tmp_path):
+    """Create a directory with a non-pipeline YAML file."""
+    yaml_dir = tmp_path / "configs"
+    yaml_dir.mkdir()
+
+    content = dedent("""\
+        database:
+          host: localhost
+          port: 5432
+          credentials:
+            user: admin
+            password: secret
+          replicas:
+            - name: replica-1
+              region: us-east
+            - name: replica-2
+              region: eu-west
+        """)
+
+    yaml_file = yaml_dir / "config.yaml"
+    yaml_file.write_text(content)
+
+    return yaml_dir
+
+
+class TestModifyGenericNonPipelineYAML:
+    """Test that modify generic works on arbitrary YAML, not just Pipeline resources."""
+
+    def test_insert(self, plain_yaml_dir, monkeypatch):
+        """Test inserting into a non-pipeline YAML file."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(plain_yaml_dir),
+            "generic",
+            "insert",
+            '["database", "replicas"]',
+            '{"name": "replica-3", "region": "ap-south"}',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        doc = load_yaml(plain_yaml_dir / "config.yaml")
+        assert len(doc["database"]["replicas"]) == 3
+        assert doc["database"]["replicas"][2]["name"] == "replica-3"
+
+    def test_replace(self, plain_yaml_dir, monkeypatch):
+        """Test replacing a value in a non-pipeline YAML file."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(plain_yaml_dir),
+            "generic",
+            "replace",
+            '["database", "host"]',
+            '"db.example.com"',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        doc = load_yaml(plain_yaml_dir / "config.yaml")
+        assert doc["database"]["host"] == "db.example.com"
+
+    def test_remove(self, plain_yaml_dir, monkeypatch):
+        """Test removing a value from a non-pipeline YAML file."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(plain_yaml_dir),
+            "generic",
+            "remove",
+            '["database", "credentials"]',
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        doc = load_yaml(plain_yaml_dir / "config.yaml")
+        assert "credentials" not in doc["database"]
+
+
 class TestModifyGenericInsert:
     """Test cases for the modify generic insert CLI command."""
 


### PR DESCRIPTION
Previously, the 'modify generic' subcommand would refuse to operate on
anything except Pipelines and certain kinds of PipelineRuns. That
greatly limits what the command can do for no good reason.

Decouple the command from the 'PipelineFileOperation' base class
to avoid the unwanted validation.

---

The main motivation for this change is to support this absolute unit of a migration script that will be necessary to get rid of the sbom-syft-generate step in the buildah task: https://github.com/chmeliik/build-definitions/blob/syft-kbc/task/buildah/0.10/migrations/0.10.5.sh. Currently, it fails to edit a `PipelineRun` that doesn't have an embedded pipeline spec.

## Testing

- [x] Tests added or updated
- [x] `tox` passes locally
