### PR TITLE
feat: add set-bundle and rename tasks to `pmt modify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ the same with `pmt modify`:
 Get more information about supported resources by `pmt modify -h`, and supported commands
 for the given resource by `pmt modify RESOURCE -h` (for example `pmt modify task -h`).
 
+#### Modifying tasks
+
+The `pmt modify task` command contains a number of subcommands for specific task modifications. Some
+of those modifications are described below.
+
+##### rename
+
+The `rename` subcommand will rename a given task. It will also update all `runAfter` references to the
+task with the new task name. The optional parameter `--task-ref-name` sets the bundle name as well.
+
+```bash
+  pmt modify task old-name rename new-name
+```
+
+##### set-bundle
+
+The `set-bundle` subcommand will set the value of the bundle for the given task. Unlike `pmt-migrate`, the
+new bundle value does not have to share a repo and image name with the current bundle. The optional parameter
+`--task-ref-name` sets the bundle name as well
+
+```bash
+  pmt modify task old-task set-bundle quay.io/sample-repo/sample-bundle@sha256:a12c9... --task-ref-name bundle-name
+``` 
+
 #### Unsupported resource?
 
 When resource you need is not supported by `pmt modify` you can use `generic` subcommand

--- a/src/pipeline_migration/actions/modify/task.py
+++ b/src/pipeline_migration/actions/modify/task.py
@@ -10,8 +10,9 @@ from ruamel.yaml.comments import CommentedSeq
 
 from pipeline_migration.yamleditor import EditYAMLEntry, YAMLPath
 from pipeline_migration.types import FilePath
-from pipeline_migration.utils import YAMLStyle
+from pipeline_migration.utils import YAMLStyle, load_yaml
 from pipeline_migration.pipeline import PipelineFileOperation, iterate_files_or_dirs
+from pipeline_migration.actions.add_task import get_task_bundle_reference
 
 logger = logging.getLogger("modify.task")
 
@@ -38,11 +39,30 @@ The following are several examples with a Konflux task push-dockerfile:
 
     Note: if the param name exist current values will be replaced, not appended
 
+* Rename a task:
+
+    pmt modify task clair-scan rename roxctl-scan
+
+* Rename a task and update the taskRef resolver name param:
+
+    pmt modify task clair-scan rename roxctl-scan --task-ref-name task-roxctl-scan
+
+* Set the bundle for a task:
+
+    pmt modify task buildah set-bundle quay.io/org/task-buildah:0.2@sha256:abc123
+
+* Set the bundle and update the taskRef resolver name param:
+
+    pmt modify task buildah set-bundle quay.io/org/task-buildah:0.2@sha256:abc123 \\
+        --task-ref-name task-buildah
+
 * Supported task modifications:
    - add-param: adds a new param to the task (or updates existing)
    - remove-param: removes the specified param from the task
    - matrix-add-param: adds a new matrix param to the task (or updates existing)
    - matrix-remove-param: removes the specified matrix param from the task
+   - rename: renames the task in the pipeline
+   - set-bundle: sets the bundle in the taskRef resolver params
 """
 
 
@@ -58,6 +78,51 @@ class ParamType(Enum):
 
 class TaskNotFoundError(Exception):
     """Task of the given name not found"""
+
+
+class DuplicateTaskNameError(Exception):
+    """Raised when a rename would create a duplicate task name in the pipeline."""
+
+
+def _get_nested(doc: Any, path: list) -> Any:
+    """Traverse a nested mapping along path, raising KeyError if any key is missing."""
+    for p in path:
+        doc = doc[p]
+    return doc
+
+
+def _update_task_ref_name(
+    task_name: str,
+    task_ref_name: str,
+    ref_params: list,
+    task_path: YAMLPath,
+    pipeline_file: FilePath,
+    style: YAMLStyle,
+) -> None:
+    """Update the 'name' param value inside taskRef.params to task_ref_name.
+
+    Logs a warning and does nothing if the 'name' param is not present in ref_params.
+    """
+    for param_index, param in enumerate(ref_params):
+        if param.get("name") == "name":
+            yamledit = EditYAMLEntry(pipeline_file, style=style)
+            yamledit.replace(
+                task_path + ["taskRef", "params", param_index, "value"],
+                task_ref_name,
+            )
+            logger.info(
+                "task '%s' in '%s': taskRef name updated to '%s'",
+                task_name,
+                pipeline_file,
+                task_ref_name,
+            )
+            break
+    else:
+        logger.warning(
+            "task '%s' in '%s': taskRef has no 'name' param, " "skipping task-ref-name update",
+            task_name,
+            pipeline_file,
+        )
 
 
 class TaskBase(PipelineFileOperation):
@@ -97,17 +162,10 @@ class TaskBase(PipelineFileOperation):
     ):
         not_found_task = [False] * len(yaml_paths)
 
-        def get_path_doc(ypath):
-            """:raises KeyError: when path doesn't exist"""
-            tmp_doc = copy.copy(loaded_doc)
-            for p in ypath:
-                tmp_doc = tmp_doc[p]
-            return tmp_doc
-
         for index, yaml_path in enumerate(yaml_paths):
             # check if path exist
             try:
-                tmp_doc = get_path_doc(yaml_path)
+                tmp_doc = _get_nested(copy.copy(loaded_doc), yaml_path)
             except KeyError:
                 not_found_task[index] = True
                 continue
@@ -202,6 +260,45 @@ def register_cli(subparser) -> None:
     subparser_remove_param.add_argument("param_name", help="parameter name", metavar="PARAM-NAME")
 
     subparser_remove_param.set_defaults(action=action_matrix_remove_param)
+
+    # rename
+    subparser_rename = subparser_mod.add_parser(
+        "rename",
+        help="Rename the task in the pipeline.",
+    )
+    subparser_rename.add_argument("new_name", help="new task name", metavar="NEW-NAME")
+    subparser_rename.add_argument(
+        "-r",
+        "--task-ref-name",
+        metavar="REF-NAME",
+        dest="task_ref_name",
+        default=None,
+        help="New value for the 'name' entry in taskRef.params (the actual task name inside "
+        "the bundle resolver). If omitted, taskRef.params is left unchanged.",
+    )
+    subparser_rename.set_defaults(action=action_rename)
+
+    # set-bundle
+    subparser_set_bundle = subparser_mod.add_parser(
+        "set-bundle",
+        help="Set the bundle in the taskRef resolver params.",
+    )
+    subparser_set_bundle.add_argument(
+        "bundle_ref",
+        type=get_task_bundle_reference,
+        help="new bundle reference (e.g. quay.io/org/task-foo:0.1@sha256:...)",
+        metavar="BUNDLE-REF",
+    )
+    subparser_set_bundle.add_argument(
+        "-r",
+        "--task-ref-name",
+        metavar="REF-NAME",
+        dest="task_ref_name",
+        default=None,
+        help="New value for the 'name' entry in taskRef.params. If omitted, the name param "
+        "is left unchanged.",
+    )
+    subparser_set_bundle.set_defaults(action=action_set_bundle)
 
 
 class ModTaskAddParamOperation(TaskBase):
@@ -626,5 +723,222 @@ def action_matrix_remove_param(args) -> None:
         search_places = [str(relative_tekton_dir.absolute())]
 
     op = ModTaskMatrixRemoveParamOperation(args.task_name, args.param_name)
+    for file_path in iterate_files_or_dirs(search_places):
+        op.handle(str(file_path))
+
+
+class ModTaskRenameOperation(TaskBase):
+    """Operation that renames a pipeline task and optionally updates its taskRef resolver name."""
+
+    def __init__(
+        self,
+        task_name: str,
+        new_name: str,
+        task_ref_name: str | None = None,
+    ) -> None:
+        super().__init__(task_name)
+        self.new_name = new_name
+        self.task_ref_name = task_ref_name
+
+    def _do_action(
+        self, tasks: CommentedSeq, path_prefix: YAMLPath, pipeline_file: FilePath, style: YAMLStyle
+    ) -> bool:
+        for index, task in enumerate(tasks):
+            if task.get("name", "") != self.task_name:
+                continue
+
+            task_path = list(path_prefix) + [index]
+
+            yamledit = EditYAMLEntry(pipeline_file, style=style)
+            yamledit.replace(task_path + ["name"], self.new_name)
+            logger.info(
+                "task '%s' in '%s': renamed to '%s'",
+                self.task_name,
+                pipeline_file,
+                self.new_name,
+            )
+
+            if self.task_ref_name is not None:
+                task_ref = task.get("taskRef", {})
+                _update_task_ref_name(
+                    self.new_name,
+                    self.task_ref_name,
+                    task_ref.get("params", []),
+                    task_path,
+                    pipeline_file,
+                    style,
+                )
+
+            return True
+
+        raise TaskNotFoundError
+
+    def _check_new_name_is_available(
+        self, loaded_doc: Any, task_paths: List[List[str]], file_path: FilePath
+    ) -> None:
+        """Raise DuplicateTaskNameError if new_name is already used by a different task."""
+        for path in task_paths:
+            try:
+                tmp = _get_nested(loaded_doc, path)
+            except KeyError:
+                continue
+            for task in tmp:
+                name = task.get("name", "")
+                if name == self.new_name and name != self.task_name:
+                    raise DuplicateTaskNameError(
+                        f"cannot rename task '{self.task_name}' to '{self.new_name}' "
+                        f"in '{file_path}': a task named '{self.new_name}' already exists"
+                    )
+
+    def _update_run_after_refs(
+        self, file_path: FilePath, style: YAMLStyle, task_paths: List[List[str]]
+    ) -> None:
+        """Replace occurrences of the old task name with the new name in all runAfter lists."""
+        for path_prefix in task_paths:
+            doc = load_yaml(file_path, style)
+            try:
+                tasks = _get_nested(doc, path_prefix)
+            except KeyError:
+                continue
+
+            for task_index, task in enumerate(tasks):
+                run_after = task.get("runAfter", [])
+                if self.task_name not in run_after:
+                    continue
+
+                new_run_after = [
+                    self.new_name if name == self.task_name else name for name in run_after
+                ]
+                yamledit = EditYAMLEntry(file_path, style=style)
+                yamledit.replace(list(path_prefix) + [task_index, "runAfter"], new_run_after)
+                logger.info(
+                    "task '%s' in '%s': runAfter updated '%s' -> '%s'",
+                    task.get("name"),
+                    file_path,
+                    self.task_name,
+                    self.new_name,
+                )
+
+    def handle_pipeline_file(self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle) -> None:
+        task_paths: List[List[str]] = [["spec", "tasks"], ["spec", "finally"]]
+        self._check_new_name_is_available(loaded_doc, task_paths, file_path)
+        super().handle_pipeline_file(file_path, loaded_doc, style)
+        self._update_run_after_refs(file_path, style, task_paths)
+
+    def handle_pipeline_run_file(
+        self, file_path: FilePath, loaded_doc: Any, style: YAMLStyle
+    ) -> None:
+        task_paths: List[List[str]] = [
+            ["spec", "pipelineSpec", "tasks"],
+            ["spec", "pipelineSpec", "finally"],
+        ]
+        self._check_new_name_is_available(loaded_doc, task_paths, file_path)
+        super().handle_pipeline_run_file(file_path, loaded_doc, style)
+        self._update_run_after_refs(file_path, style, task_paths)
+
+
+def action_rename(args) -> None:
+    """CLI action handler to rename a task in pipeline files."""
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+
+    op = ModTaskRenameOperation(args.task_name, args.new_name, args.task_ref_name)
+    for file_path in iterate_files_or_dirs(search_places):
+        try:
+            op.handle(str(file_path))
+        except DuplicateTaskNameError as e:
+            raise SystemExit(f"error: {e}") from e
+
+
+class ModTaskSetBundleOperation(TaskBase):
+    """Operation that sets the bundle param in taskRef.params and optionally updates the name."""
+
+    def __init__(
+        self,
+        task_name: str,
+        bundle_ref: str,
+        task_ref_name: str | None = None,
+    ) -> None:
+        super().__init__(task_name)
+        self.bundle_ref = bundle_ref
+        self.task_ref_name = task_ref_name
+
+    def _do_action(
+        self, tasks: CommentedSeq, path_prefix: YAMLPath, pipeline_file: FilePath, style: YAMLStyle
+    ) -> bool:
+        for index, task in enumerate(tasks):
+            if task.get("name", "") != self.task_name:
+                continue
+
+            task_path = list(path_prefix) + [index]
+            task_ref = task.get("taskRef", {})
+            ref_params = task_ref.get("params", [])
+
+            if not ref_params:
+                logger.warning(
+                    "task '%s' in '%s': taskRef has no params, skipping set-bundle",
+                    self.task_name,
+                    pipeline_file,
+                )
+                return False
+
+            bundle_index = None
+            for param_index, param in enumerate(ref_params):
+                if param.get("name") == "bundle":
+                    bundle_index = param_index
+                    break
+
+            if bundle_index is None:
+                logger.warning(
+                    "task '%s' in '%s': taskRef has no 'bundle' param, skipping set-bundle",
+                    self.task_name,
+                    pipeline_file,
+                )
+                return False
+
+            if ref_params[bundle_index].get("value") != self.bundle_ref:
+                yamledit = EditYAMLEntry(pipeline_file, style=style)
+                yamledit.replace(
+                    task_path + ["taskRef", "params", bundle_index, "value"],
+                    self.bundle_ref,
+                )
+                logger.info(
+                    "task '%s' in '%s': bundle updated to '%s'",
+                    self.task_name,
+                    pipeline_file,
+                    self.bundle_ref,
+                )
+            else:
+                logger.info(
+                    "task '%s' in '%s': bundle already set to required value",
+                    self.task_name,
+                    pipeline_file,
+                )
+
+            if self.task_ref_name is not None:
+                _update_task_ref_name(
+                    self.task_name,
+                    self.task_ref_name,
+                    ref_params,
+                    task_path,
+                    pipeline_file,
+                    style,
+                )
+
+            return True
+
+        raise TaskNotFoundError
+
+
+def action_set_bundle(args) -> None:
+    """CLI action handler to set the bundle in taskRef.params for a task in pipeline files."""
+    search_places = [path for path in args.file_or_dir if path]
+    relative_tekton_dir = Path("./.tekton")
+    if not search_places and relative_tekton_dir.exists():
+        search_places = [str(relative_tekton_dir.absolute())]
+
+    op = ModTaskSetBundleOperation(args.task_name, args.bundle_ref, args.task_ref_name)
     for file_path in iterate_files_or_dirs(search_places):
         op.handle(str(file_path))

--- a/tests/actions/modify/test_task.py
+++ b/tests/actions/modify/test_task.py
@@ -6,7 +6,10 @@ from pipeline_migration.actions.modify.task import (
     ModTaskRemoveParamOperation,
     ModTaskMatrixAddParamOperation,
     ModTaskMatrixRemoveParamOperation,
+    ModTaskRenameOperation,
+    ModTaskSetBundleOperation,
     TaskNotFoundError,
+    DuplicateTaskNameError,
 )
 from pipeline_migration.utils import load_yaml, YAMLStyle
 
@@ -1724,6 +1727,600 @@ class TestModTaskMatrixRemoveParamOperation:
             """)
 
         assert read_file_content(pipeline_run_matrix_include_only_yaml_file) == expected
+
+
+@pytest.fixture
+def pipeline_bundles_yaml_file(create_yaml_file):
+    """Pipeline YAML with a bundles-resolver taskRef, used for rename tests."""
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clair-scan
+              taskRef:
+                resolver: bundles
+                params:
+                  - name: name
+                    value: task-clair-scan
+                  - name: bundle
+                    value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                  - name: kind
+                    value: task
+              params:
+                - name: image-url
+                  value: $(tasks.build.results.IMAGE_URL)
+            - name: build
+              taskRef:
+                name: buildah
+        """)
+    return create_yaml_file(content)
+
+
+@pytest.fixture
+def pipeline_run_bundles_yaml_file(create_yaml_file):
+    """PipelineRun YAML with a bundles-resolver taskRef, used for rename tests."""
+    content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            tasks:
+              - name: clair-scan
+                taskRef:
+                  resolver: bundles
+                  params:
+                    - name: name
+                      value: task-clair-scan
+                    - name: bundle
+                      value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                    - name: kind
+                      value: task
+                params:
+                  - name: image-url
+                    value: $(tasks.build.results.IMAGE_URL)
+              - name: build
+                taskRef:
+                  name: buildah
+        """)
+    return create_yaml_file(content)
+
+
+class TestModTaskRenameOperation:
+    """Test cases for ModTaskRenameOperation."""
+
+    def test_initialization(self):
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan")
+        assert op.task_name == "clair-scan"
+        assert op.new_name == "roxctl-scan"
+        assert op.task_ref_name is None
+
+    def test_initialization_with_task_ref_name(self):
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan", "task-roxctl-scan")
+        assert op.task_ref_name == "task-roxctl-scan"
+
+    def test_rename_task_name(self, pipeline_yaml_file):
+        op = ModTaskRenameOperation("clone", "new-clone")
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_yaml_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert "new-clone" in task_names
+        assert "clone" not in task_names
+
+    def test_rename_does_not_affect_other_tasks(self, pipeline_yaml_file):
+        op = ModTaskRenameOperation("clone", "new-clone")
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        op._do_action(tasks, ["spec", "tasks"], pipeline_yaml_file, style)
+
+        doc = load_yaml(pipeline_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert "build" in task_names
+        assert "test-task" in task_names
+
+    def test_rename_with_task_ref_name(self, pipeline_bundles_yaml_file):
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan", "task-roxctl-scan")
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_bundles_yaml_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert "roxctl-scan" in task_names
+        assert "clair-scan" not in task_names
+
+        new_task = next(t for t in doc["spec"]["tasks"] if t["name"] == "roxctl-scan")
+        taskref_params = new_task["taskRef"]["params"]
+        name_param = next(p for p in taskref_params if p["name"] == "name")
+        assert name_param["value"] == "task-roxctl-scan"
+
+    def test_task_ref_name_skipped_when_no_taskref_params(self, pipeline_yaml_file):
+        """When taskRef has no params (non-bundles style), --task-ref-name is a no-error no-op."""
+        op = ModTaskRenameOperation("clone", "new-clone", "task-new-clone")
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_yaml_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert "new-clone" in task_names
+
+    def test_task_not_found(self, pipeline_yaml_file):
+        op = ModTaskRenameOperation("nonexistent", "something-else")
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        with pytest.raises(TaskNotFoundError):
+            op._do_action(tasks, ["spec", "tasks"], pipeline_yaml_file, style)
+
+        doc = load_yaml(pipeline_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert task_names == ["clone", "build", "test-task"]
+
+    def test_handle_pipeline_file(self, pipeline_bundles_yaml_file):
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan", "task-roxctl-scan")
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+
+        op.handle_pipeline_file(pipeline_bundles_yaml_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        tasks = doc["spec"]["tasks"]
+        assert tasks[0]["name"] == "roxctl-scan"
+        name_param = next(p for p in tasks[0]["taskRef"]["params"] if p["name"] == "name")
+        assert name_param["value"] == "task-roxctl-scan"
+
+    def test_handle_pipeline_run_file(self, pipeline_run_bundles_yaml_file):
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan", "task-roxctl-scan")
+
+        loaded_doc = load_yaml(pipeline_run_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_run_bundles_yaml_file)
+
+        op.handle_pipeline_run_file(pipeline_run_bundles_yaml_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_run_bundles_yaml_file)
+        tasks = doc["spec"]["pipelineSpec"]["tasks"]
+        assert tasks[0]["name"] == "roxctl-scan"
+        name_param = next(p for p in tasks[0]["taskRef"]["params"] if p["name"] == "name")
+        assert name_param["value"] == "task-roxctl-scan"
+
+    def test_handle_pipeline_file_finally(self, create_yaml_file):
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              finally:
+                - name: clair-scan
+                  taskRef:
+                    resolver: bundles
+                    params:
+                      - name: name
+                        value: task-clair-scan
+                      - name: bundle
+                        value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                      - name: kind
+                        value: task
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan", "task-roxctl-scan")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+
+        op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_file)
+        tasks = doc["spec"]["finally"]
+        assert tasks[0]["name"] == "roxctl-scan"
+        name_param = next(p for p in tasks[0]["taskRef"]["params"] if p["name"] == "name")
+        assert name_param["value"] == "task-roxctl-scan"
+
+    def test_duplicate_name_raises_error(self, create_yaml_file):
+        """Renaming to a name already used by another task must raise DuplicateTaskNameError."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clone", "build")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+
+        with pytest.raises(DuplicateTaskNameError, match="'build' already exists"):
+            op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+        # File must be unchanged
+        doc = load_yaml(pipeline_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert task_names == ["clone", "build"]
+
+    def test_duplicate_name_across_tasks_and_finally(self, create_yaml_file):
+        """Renaming a tasks-section task to a name used in finally must fail."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+              finally:
+                - name: notify
+                  taskRef:
+                    name: slack-notify
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clone", "notify")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+
+        with pytest.raises(DuplicateTaskNameError):
+            op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+    def test_run_after_updated_on_rename(self, create_yaml_file):
+        """runAfter references to the renamed task are updated in other tasks."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+                  runAfter:
+                    - clone
+                - name: test-task
+                  taskRef:
+                    name: test-runner
+                  runAfter:
+                    - clone
+                    - build
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clone", "git-clone-task")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+        op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_file)
+        tasks = {t["name"]: t for t in doc["spec"]["tasks"]}
+        assert "git-clone-task" in tasks
+        assert "clone" not in tasks
+        assert tasks["build"]["runAfter"] == ["git-clone-task"]
+        assert tasks["test-task"]["runAfter"] == ["git-clone-task", "build"]
+
+    def test_run_after_updated_in_finally_tasks(self, create_yaml_file):
+        """runAfter in finally tasks referencing the renamed task are also updated."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+                  runAfter:
+                    - clone
+              finally:
+                - name: notify
+                  taskRef:
+                    name: slack-notify
+                  runAfter:
+                    - clone
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clone", "git-clone-task")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+        op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_file)
+        tasks = {t["name"]: t for t in doc["spec"]["tasks"]}
+        finally_tasks = {t["name"]: t for t in doc["spec"]["finally"]}
+        assert "git-clone-task" in tasks
+        assert tasks["build"]["runAfter"] == ["git-clone-task"]
+        assert finally_tasks["notify"]["runAfter"] == ["git-clone-task"]
+
+    def test_run_after_updated_in_pipeline_run(self, create_yaml_file):
+        """runAfter references are updated in PipelineRun files too."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: PipelineRun
+            metadata:
+              name: test-pipeline-run
+            spec:
+              pipelineSpec:
+                tasks:
+                  - name: clone
+                    taskRef:
+                      name: git-clone
+                  - name: build
+                    taskRef:
+                      name: buildah
+                    runAfter:
+                      - clone
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskRenameOperation("clone", "git-clone-task")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+        op.handle_pipeline_run_file(pipeline_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_file)
+        tasks = {t["name"]: t for t in doc["spec"]["pipelineSpec"]["tasks"]}
+        assert "git-clone-task" in tasks
+        assert tasks["build"]["runAfter"] == ["git-clone-task"]
+
+    def test_no_run_after_refs_is_noop(self, pipeline_bundles_yaml_file):
+        """When no tasks reference the renamed task in runAfter, the rename still works."""
+        op = ModTaskRenameOperation("clair-scan", "roxctl-scan")
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        op.handle_pipeline_file(pipeline_bundles_yaml_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert "roxctl-scan" in task_names
+        assert "clair-scan" not in task_names
+
+
+class TestModTaskSetBundleOperation:
+    """Test cases for ModTaskSetBundleOperation."""
+
+    NEW_BUNDLE = "quay.io/org/task-clair-scan:0.2@sha256:def456"
+
+    def test_initialization(self):
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+        assert op.task_name == "clair-scan"
+        assert op.bundle_ref == self.NEW_BUNDLE
+        assert op.task_ref_name is None
+
+    def test_initialization_with_task_ref_name(self):
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE, "task-clair-scan-v2")
+        assert op.task_ref_name == "task-clair-scan-v2"
+
+    def test_set_bundle(self, pipeline_bundles_yaml_file):
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_bundles_yaml_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        task = next(t for t in doc["spec"]["tasks"] if t["name"] == "clair-scan")
+        bundle_param = next(p for p in task["taskRef"]["params"] if p["name"] == "bundle")
+        assert bundle_param["value"] == self.NEW_BUNDLE
+
+    def test_set_bundle_already_set(self, pipeline_bundles_yaml_file):
+        """Returns True without modifying the file when bundle is already the target value."""
+        current_bundle = "quay.io/org/task-clair-scan:0.1@sha256:abc123"
+        op = ModTaskSetBundleOperation("clair-scan", current_bundle)
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        original_content = read_file_content(pipeline_bundles_yaml_file)
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_bundles_yaml_file, style)
+        assert result is True
+        assert read_file_content(pipeline_bundles_yaml_file) == original_content
+
+    def test_set_bundle_with_task_ref_name(self, pipeline_bundles_yaml_file):
+        """Updates both the bundle and the taskRef name param when task_ref_name is given."""
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE, "task-clair-scan-v2")
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_bundles_yaml_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        task = next(t for t in doc["spec"]["tasks"] if t["name"] == "clair-scan")
+        ref_params = task["taskRef"]["params"]
+        bundle_param = next(p for p in ref_params if p["name"] == "bundle")
+        name_param = next(p for p in ref_params if p["name"] == "name")
+        assert bundle_param["value"] == self.NEW_BUNDLE
+        assert name_param["value"] == "task-clair-scan-v2"
+
+    def test_task_without_taskref_params_returns_false(self, pipeline_yaml_file):
+        """Returns False when the task's taskRef has no params (non-bundles resolver style)."""
+        op = ModTaskSetBundleOperation("clone", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_yaml_file)
+        style = YAMLStyle.detect(pipeline_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_yaml_file, style)
+        assert result is False
+
+    def test_task_without_bundle_param_returns_false(self, create_yaml_file):
+        """Returns False when taskRef has params but none named 'bundle'."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clair-scan
+                  taskRef:
+                    resolver: bundles
+                    params:
+                      - name: name
+                        value: task-clair-scan
+                      - name: kind
+                        value: task
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_file, style)
+        assert result is False
+
+    def test_task_ref_name_skipped_when_no_name_param(self, create_yaml_file):
+        """Warns and skips the name update when taskRef has no 'name' param."""
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clair-scan
+                  taskRef:
+                    resolver: bundles
+                    params:
+                      - name: bundle
+                        value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                      - name: kind
+                        value: task
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE, "task-clair-scan-v2")
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        result = op._do_action(tasks, ["spec", "tasks"], pipeline_file, style)
+        assert result is True
+
+        doc = load_yaml(pipeline_file)
+        task = next(t for t in doc["spec"]["tasks"] if t["name"] == "clair-scan")
+        bundle_param = next(p for p in task["taskRef"]["params"] if p["name"] == "bundle")
+        assert bundle_param["value"] == self.NEW_BUNDLE
+
+    def test_task_not_found_raises(self, pipeline_bundles_yaml_file):
+        op = ModTaskSetBundleOperation("nonexistent", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+        tasks = loaded_doc["spec"]["tasks"]
+
+        with pytest.raises(TaskNotFoundError):
+            op._do_action(tasks, ["spec", "tasks"], pipeline_bundles_yaml_file, style)
+
+    def test_handle_pipeline_file(self, pipeline_bundles_yaml_file):
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_bundles_yaml_file)
+
+        op.handle_pipeline_file(pipeline_bundles_yaml_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_bundles_yaml_file)
+        task = next(t for t in doc["spec"]["tasks"] if t["name"] == "clair-scan")
+        bundle_param = next(p for p in task["taskRef"]["params"] if p["name"] == "bundle")
+        assert bundle_param["value"] == self.NEW_BUNDLE
+
+    def test_handle_pipeline_run_file(self, pipeline_run_bundles_yaml_file):
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_run_bundles_yaml_file)
+        style = YAMLStyle.detect(pipeline_run_bundles_yaml_file)
+
+        op.handle_pipeline_run_file(pipeline_run_bundles_yaml_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_run_bundles_yaml_file)
+        task = next(t for t in doc["spec"]["pipelineSpec"]["tasks"] if t["name"] == "clair-scan")
+        bundle_param = next(p for p in task["taskRef"]["params"] if p["name"] == "bundle")
+        assert bundle_param["value"] == self.NEW_BUNDLE
+
+    def test_handle_pipeline_file_finally(self, create_yaml_file):
+        content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              finally:
+                - name: clair-scan
+                  taskRef:
+                    resolver: bundles
+                    params:
+                      - name: name
+                        value: task-clair-scan
+                      - name: bundle
+                        value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                      - name: kind
+                        value: task
+            """)
+        pipeline_file = create_yaml_file(content)
+        op = ModTaskSetBundleOperation("clair-scan", self.NEW_BUNDLE)
+
+        loaded_doc = load_yaml(pipeline_file)
+        style = YAMLStyle.detect(pipeline_file)
+
+        op.handle_pipeline_file(pipeline_file, loaded_doc, style)
+
+        doc = load_yaml(pipeline_file)
+        task = next(t for t in doc["spec"]["finally"] if t["name"] == "clair-scan")
+        bundle_param = next(p for p in task["taskRef"]["params"] if p["name"] == "bundle")
+        assert bundle_param["value"] == self.NEW_BUNDLE
 
 
 class TestComplexScenarios:

--- a/tests/actions/modify/test_task_cli.py
+++ b/tests/actions/modify/test_task_cli.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import responses
+from responses.matchers import query_param_matcher
 
 from pipeline_migration.cli import entry_point
 from pipeline_migration.utils import load_yaml
@@ -1079,6 +1081,558 @@ class TestModifyTaskMatrixRemoveParam:
         # Verify parameter was added
         for yaml_file in component_matrix_pipeline_dir.tekton_dir.glob("*.yaml"):
             verify_matrix_param_removed(yaml_file, "clone", "url")
+
+
+@pytest.fixture
+def component_bundles_pipeline_dir(tmp_path):
+    """Pipeline directory with bundles-resolver taskRef for rename tests."""
+    component_dir = tmp_path / "component_bundles"
+    tekton_dir = component_dir / ".tekton"
+    tekton_dir.mkdir(parents=True)
+
+    pipeline_content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: test-pipeline
+        spec:
+          tasks:
+            - name: clair-scan
+              taskRef:
+                resolver: bundles
+                params:
+                  - name: name
+                    value: task-clair-scan
+                  - name: bundle
+                    value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                  - name: kind
+                    value: task
+              params:
+                - name: image-url
+                  value: $(tasks.build.results.IMAGE_URL)
+            - name: build
+              taskRef:
+                name: buildah
+        """)
+    (tekton_dir / "pipeline.yaml").write_text(pipeline_content)
+
+    pipeline_run_content = dedent("""\
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: test-pipeline-run
+        spec:
+          pipelineSpec:
+            tasks:
+              - name: clair-scan
+                taskRef:
+                  resolver: bundles
+                  params:
+                    - name: name
+                      value: task-clair-scan
+                    - name: bundle
+                      value: quay.io/org/task-clair-scan:0.1@sha256:abc123
+                    - name: kind
+                      value: task
+                params:
+                  - name: image-url
+                    value: $(tasks.build.results.IMAGE_URL)
+              - name: build
+                taskRef:
+                  name: buildah
+        """)
+    (tekton_dir / "pipeline-run.yaml").write_text(pipeline_run_content)
+
+    return ComponentRepo(component_dir)
+
+
+def verify_task_renamed(file_path: Path, old_name: str, new_name: str):
+    """Verify a task was renamed from old_name to new_name."""
+    doc = load_yaml(file_path)
+    tasks = None
+    if "spec" in doc and "tasks" in doc["spec"]:
+        tasks = doc["spec"]["tasks"]
+    elif "spec" in doc and "pipelineSpec" in doc["spec"]:
+        tasks = doc["spec"]["pipelineSpec"].get("tasks", [])
+
+    assert tasks is not None, f"No tasks found in {file_path}"
+    task_names = [t.get("name") for t in tasks]
+    assert new_name in task_names, f"New task '{new_name}' not found in {file_path}"
+    assert old_name not in task_names, f"Old task '{old_name}' still present in {file_path}"
+
+
+def verify_taskref_name_param(file_path: Path, task_name: str, expected_value: str):
+    """Verify the 'name' entry in taskRef.params has the expected value."""
+    doc = load_yaml(file_path)
+    tasks = None
+    if "spec" in doc and "tasks" in doc["spec"]:
+        tasks = doc["spec"]["tasks"]
+    elif "spec" in doc and "pipelineSpec" in doc["spec"]:
+        tasks = doc["spec"]["pipelineSpec"].get("tasks", [])
+
+    assert tasks is not None
+    task = next((t for t in tasks if t.get("name") == task_name), None)
+    assert task is not None, f"Task '{task_name}' not found in {file_path}"
+
+    task_ref = task.get("taskRef", {})
+    params = task_ref.get("params", [])
+    name_param = next((p for p in params if p.get("name") == "name"), None)
+    assert name_param is not None, f"taskRef has no 'name' param in task '{task_name}'"
+    assert (
+        name_param["value"] == expected_value
+    ), f"taskRef name param value is '{name_param['value']}', expected '{expected_value}'"
+
+
+class TestModifyTaskRename:
+    """Test cases for the modify task rename CLI command."""
+
+    def test_rename_task(self, component_pipeline_dir, monkeypatch):
+        """Test renaming a task."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "task",
+            "clone",
+            "rename",
+            "new-clone",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_task_renamed(yaml_file, "clone", "new-clone")
+
+    def test_rename_with_task_ref_name(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test renaming a task and updating taskRef.params[name]."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "rename",
+            "roxctl-scan",
+            "--task-ref-name",
+            "task-roxctl-scan",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_task_renamed(yaml_file, "clair-scan", "roxctl-scan")
+            verify_taskref_name_param(yaml_file, "roxctl-scan", "task-roxctl-scan")
+
+    def test_rename_short_flag_for_task_ref_name(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test using -r short flag for --task-ref-name."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "rename",
+            "roxctl-scan",
+            "-r",
+            "task-roxctl-scan",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_name_param(yaml_file, "roxctl-scan", "task-roxctl-scan")
+
+    def test_rename_nonexistent_task(self, component_pipeline_dir, monkeypatch):
+        """Test renaming a task that doesn't exist (should warn and do nothing)."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "task",
+            "nonexistent-task",
+            "rename",
+            "something-else",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        pipeline_file = component_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert task_names == ["clone", "build", "test-task"]
+
+    def test_rename_task_ref_name_skipped_when_no_params(self, component_pipeline_dir, monkeypatch):
+        """--task-ref-name is silently skipped when taskRef has no params (non-bundles style)."""
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_pipeline_dir.tekton_dir),
+            "task",
+            "clone",
+            "rename",
+            "new-clone",
+            "--task-ref-name",
+            "task-new-clone",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_task_renamed(yaml_file, "clone", "new-clone")
+
+    def test_use_relative_tekton_dir(self, component_pipeline_dir, monkeypatch):
+        """Test using the default .tekton directory."""
+        monkeypatch.chdir(str(component_pipeline_dir.base_path))
+
+        cmd = ["pmt", "modify", "task", "clone", "rename", "new-clone"]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_task_renamed(yaml_file, "clone", "new-clone")
+
+    def test_missing_new_name_argument(self, monkeypatch):
+        """Test that missing new name argument causes an error."""
+        cmd = ["pmt", "modify", "task", "clone", "rename"]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
+
+    def test_rename_to_existing_name_exits_with_error(self, tmp_path, monkeypatch):
+        """Renaming a task to a name already in use must exit with a non-zero status."""
+        tekton_dir = tmp_path / ".tekton"
+        tekton_dir.mkdir()
+        pipeline_content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+            """)
+        (tekton_dir / "pipeline.yaml").write_text(pipeline_content)
+
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(tekton_dir),
+            "task",
+            "clone",
+            "rename",
+            "build",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit) as exc_info:
+            entry_point()
+        assert exc_info.value.code != 0
+
+        # File must be unchanged
+        doc = load_yaml(tekton_dir / "pipeline.yaml")
+        task_names = [t["name"] for t in doc["spec"]["tasks"]]
+        assert task_names == ["clone", "build"]
+
+    def test_rename_updates_run_after(self, tmp_path, monkeypatch):
+        """Renaming a task also updates runAfter references in other tasks."""
+        tekton_dir = tmp_path / ".tekton"
+        tekton_dir.mkdir()
+        pipeline_content = dedent("""\
+            apiVersion: tekton.dev/v1
+            kind: Pipeline
+            metadata:
+              name: test-pipeline
+            spec:
+              tasks:
+                - name: clone
+                  taskRef:
+                    name: git-clone
+                - name: build
+                  taskRef:
+                    name: buildah
+                  runAfter:
+                    - clone
+                - name: test-task
+                  taskRef:
+                    name: test-runner
+                  runAfter:
+                    - build
+            """)
+        (tekton_dir / "pipeline.yaml").write_text(pipeline_content)
+
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(tekton_dir),
+            "task",
+            "clone",
+            "rename",
+            "git-clone-task",
+        ]
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        doc = load_yaml(tekton_dir / "pipeline.yaml")
+        tasks = {t["name"]: t for t in doc["spec"]["tasks"]}
+        assert "git-clone-task" in tasks
+        assert "clone" not in tasks
+        assert tasks["build"]["runAfter"] == ["git-clone-task"]
+        # test-task references build, which was not renamed — should be unchanged
+        assert tasks["test-task"]["runAfter"] == ["build"]
+
+
+def verify_taskref_bundle_param(file_path: Path, task_name: str, expected_value: str):
+    """Verify the 'bundle' entry in taskRef.params has the expected value."""
+    doc = load_yaml(file_path)
+    tasks = None
+    if "spec" in doc and "tasks" in doc["spec"]:
+        tasks = doc["spec"]["tasks"]
+    elif "spec" in doc and "pipelineSpec" in doc["spec"]:
+        tasks = doc["spec"]["pipelineSpec"].get("tasks", [])
+
+    assert tasks is not None
+    task = next((t for t in tasks if t.get("name") == task_name), None)
+    assert task is not None, f"Task '{task_name}' not found in {file_path}"
+
+    task_ref = task.get("taskRef", {})
+    params = task_ref.get("params", [])
+    bundle_param = next((p for p in params if p.get("name") == "bundle"), None)
+    assert bundle_param is not None, f"taskRef has no 'bundle' param in task '{task_name}'"
+    assert (
+        bundle_param["value"] == expected_value
+    ), f"taskRef bundle param value is '{bundle_param['value']}', expected '{expected_value}'"
+
+
+class TestModifyTaskSetBundle:
+    """Test cases for the modify task set-bundle CLI command."""
+
+    @responses.activate
+    def test_set_bundle(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test setting the bundle for a task."""
+        new_bundle = "quay.io/org/task-clair-scan:0.2@sha256:newdigest"
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-clair-scan/tag/",
+            json={"tags": [{"manifest_digest": "sha256:newdigest"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.2"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "set-bundle",
+            new_bundle,
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_bundle_param(yaml_file, "clair-scan", new_bundle)
+
+    @responses.activate
+    def test_set_bundle_with_task_ref_name(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test setting the bundle and updating taskRef.params[name] simultaneously."""
+        new_bundle = "quay.io/org/task-roxctl-scan:0.1@sha256:newdigest"
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-roxctl-scan/tag/",
+            json={"tags": [{"manifest_digest": "sha256:newdigest"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.1"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "set-bundle",
+            new_bundle,
+            "--task-ref-name",
+            "task-roxctl-scan",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_bundle_param(yaml_file, "clair-scan", new_bundle)
+            verify_taskref_name_param(yaml_file, "clair-scan", "task-roxctl-scan")
+
+    @responses.activate
+    def test_set_bundle_short_flag_for_task_ref_name(
+        self, component_bundles_pipeline_dir, monkeypatch
+    ):
+        """Test using -r short flag for --task-ref-name."""
+        new_bundle = "quay.io/org/task-clair-scan:0.2@sha256:updated"
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-clair-scan/tag/",
+            json={"tags": [{"manifest_digest": "sha256:updated"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.2"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "set-bundle",
+            new_bundle,
+            "-r",
+            "task-clair-scan-v2",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_bundle_param(yaml_file, "clair-scan", new_bundle)
+            verify_taskref_name_param(yaml_file, "clair-scan", "task-clair-scan-v2")
+
+    @responses.activate
+    def test_set_bundle_already_set(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test set-bundle when bundle is already the desired value (no-op)."""
+        existing_bundle = "quay.io/org/task-clair-scan:0.1@sha256:abc123"
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-clair-scan/tag/",
+            json={"tags": [{"manifest_digest": "sha256:abc123"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.1"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "clair-scan",
+            "set-bundle",
+            existing_bundle,
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_bundle_param(yaml_file, "clair-scan", existing_bundle)
+
+    @responses.activate
+    def test_set_bundle_nonexistent_task(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test set-bundle on a task that doesn't exist (should warn and do nothing)."""
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task/tag/",
+            json={"tags": [{"manifest_digest": "sha256:abc"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.1"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "nonexistent-task",
+            "set-bundle",
+            "quay.io/org/task:0.1@sha256:abc",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+    @responses.activate
+    def test_set_bundle_task_without_taskref_params(
+        self, component_bundles_pipeline_dir, monkeypatch
+    ):
+        """Test set-bundle on a task whose taskRef has no params (non-bundles style)."""
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-buildah/tag/",
+            json={"tags": [{"manifest_digest": "sha256:xyz"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.2"})
+            ],
+        )
+        cmd = [
+            "pmt",
+            "modify",
+            "--file-or-dir",
+            str(component_bundles_pipeline_dir.tekton_dir),
+            "task",
+            "build",
+            "set-bundle",
+            "quay.io/org/task-buildah:0.2@sha256:xyz",
+        ]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        # build task uses old-style taskRef with no params; bundle should not be touched
+        pipeline_file = component_bundles_pipeline_dir.tekton_dir / "pipeline.yaml"
+        doc = load_yaml(pipeline_file)
+        build_task = next(t for t in doc["spec"]["tasks"] if t["name"] == "build")
+        assert "params" not in build_task.get(
+            "taskRef", {}
+        ), "build taskRef should not have gained params"
+
+    @responses.activate
+    def test_set_bundle_use_relative_tekton_dir(self, component_bundles_pipeline_dir, monkeypatch):
+        """Test set-bundle using the default .tekton directory."""
+        monkeypatch.chdir(str(component_bundles_pipeline_dir.base_path))
+
+        new_bundle = "quay.io/org/task-clair-scan:0.3@sha256:relativetest"
+        responses.get(
+            "https://quay.io/api/v1/repository/org/task-clair-scan/tag/",
+            json={"tags": [{"manifest_digest": "sha256:relativetest"}], "has_additional": False},
+            match=[
+                query_param_matcher({"page": "1", "onlyActiveTags": "true", "specificTag": "0.3"})
+            ],
+        )
+        cmd = ["pmt", "modify", "task", "clair-scan", "set-bundle", new_bundle]
+
+        monkeypatch.setattr("sys.argv", cmd)
+        entry_point()
+
+        for yaml_file in component_bundles_pipeline_dir.tekton_dir.glob("*.yaml"):
+            verify_taskref_bundle_param(yaml_file, "clair-scan", new_bundle)
+
+    def test_set_bundle_missing_bundle_ref_argument(self, monkeypatch):
+        """Test that missing BUNDLE-REF argument causes an error."""
+        cmd = ["pmt", "modify", "task", "clair-scan", "set-bundle"]
+
+        monkeypatch.setattr("sys.argv", cmd)
+
+        with pytest.raises(SystemExit):
+            entry_point()
 
 
 class TestModifyTaskErrorHandling:


### PR DESCRIPTION
This commit adds the subcommand `pmt modify task rename`. This subcommand renames a task. It also adds the subcommand `pmt modify task set-bundle` which sets the bundle for a given task. This differs from `pmt migrate --new-bundle` in that `pmt migrate` only changes the value of bundles that reference the same image whereas `set-bundle` allows the user to overwrite the bundle completely. Both subcommands accept the optional parameter `--task-ref-name` flag that, if set, updates the task.taskRef.name field.

## Summary

<!-- Describe what this PR changes and why -->

## Testing

- [ ] Tests added or updated
- [ ] `tox` passes locally
