### PR TITLE
fix(yamleditor): comment indentation shift during scalar replacement

### DIFF
--- a/src/pipeline_migration/yamleditor.py
+++ b/src/pipeline_migration/yamleditor.py
@@ -29,6 +29,70 @@ PathStack: TypeAlias = List[Tuple[CommentedSeq | CommentedMap, str | int | None]
 EOF = -1
 
 
+def _adjust_comment_token(token: Any, offset: int) -> None:
+    """Shift a CommentToken's column position and embedded whitespace left by ``offset``.
+
+    Handles None (empty slot), str (bare whitespace stored by ruamel), and
+    CommentToken objects.  ``offset`` is the absolute column the subtree
+    originally started at; subtracting it realigns comments to column 0.
+    """
+    if token is None or isinstance(token, str):  # ruamel stores some slots as plain str
+        return
+    if hasattr(token, "start_mark") and token.start_mark is not None:
+        token.start_mark.column = max(0, token.start_mark.column - offset)
+    value = token.value
+    if isinstance(value, str) and "\n" in value:  # multi-line: fix embedded indentation
+        lines = value.split("\n")
+        adjusted: list[str] = []
+        for line in lines:
+            stripped = line.lstrip(" ")
+            indent = len(line) - len(stripped)
+            adjusted.append(" " * max(0, indent - offset) + stripped)
+        token.value = "\n".join(adjusted)
+
+
+def _adjust_comment_columns(node: Any, offset: int) -> None:
+    """Recursively shift CommentToken column positions by ``-offset``.
+
+    ruamel.yaml bakes absolute columns into CommentToken objects.  When a
+    subtree is re-serialized at column 0, code lines shift but comments don't.
+    This walk visits CommentedMap/CommentedSeq nodes (via ``ca``) and corrects
+    every token.  Block-scalar content (``|``/``>``) lives in scalar values,
+    not CommentTokens, so it is unaffected.
+    """
+    if offset <= 0:
+        return
+
+    if hasattr(node, "ca"):  # "ca" = ruamel CommentAttribute
+        ca = node.ca
+        if ca.comment:
+            _adjust_comment_token(ca.comment[0], offset)  # end-of-line comment
+            if len(ca.comment) > 1 and ca.comment[1]:
+                for tok in ca.comment[1]:  # block of preceding comments
+                    _adjust_comment_token(tok, offset)
+        for comments in ca.items.values():  # per-key/index comment tuples
+            for entry in comments:
+                if entry is None:
+                    continue
+                if isinstance(entry, list):  # slot holds multiple tokens
+                    for tok in entry:
+                        _adjust_comment_token(tok, offset)
+                else:
+                    _adjust_comment_token(entry, offset)
+        if ca.end:  # trailing comments after last child
+            for tok in ca.end:
+                _adjust_comment_token(tok, offset)
+
+    # Recurse into children: ca only holds comments for THIS node;
+    # nested dicts/lists have their own ca with their own tokens.
+    if isinstance(node, dict):
+        for v in node.values():
+            _adjust_comment_columns(v, offset)
+    elif isinstance(node, list):
+        for item in node:
+            _adjust_comment_columns(item, offset)
+
+
 class EditYAMLEntry:
     """Provides manipulation interface to YAML files using direct writes
     into YAML file, without regenerating the whole YAML content.
@@ -391,10 +455,26 @@ class EditYAMLEntry:
         return EOF
 
     def _gen_yaml_str(self, data: Any, col: int, seq_block: bool = False) -> str:
-        """Generate an indented YAML string for the given data at the specified column."""
+        """Generate an indented YAML string for the given data at the specified column.
+
+        Comment columns are pre-adjusted because ruamel.yaml bakes absolute
+        column positions into CommentToken objects. When a subtree loaded from
+        a parent is dumped in isolation, code lines are re-indented by the
+        emitter but comment positions are not, causing them to shift.
+        """
+        if col > 0:
+            data = copy.deepcopy(data)  # avoid mutating caller's comment metadata
         if seq_block:
             data = [data]
         yaml = create_yaml_obj(style=self.style)
+        # The dump indents `- ` by sequence_dash_offset, which textwrap.dedent
+        # later strips from *all* lines including comments. Reduce the comment
+        # adjustment accordingly so the net result lands comments at their
+        # original column.
+        comment_offset = col
+        if seq_block:
+            comment_offset = max(0, col - yaml.sequence_dash_offset)
+        _adjust_comment_columns(data, comment_offset)
         stream = StringIO()
         yaml.dump(
             data,

--- a/tests/test_yamleditor.py
+++ b/tests/test_yamleditor.py
@@ -1361,6 +1361,231 @@ class TestEditYAMLEntryComments:
             """)
         assert read_file_content(comments_yaml_file) == expected
 
+    def test_replace_scalar_preserves_inter_task_comment(self, create_yaml_file):
+        """Comment between tasks stays at the list-item indentation level."""
+        content = dedent("""\
+            spec:
+              tasks:
+                - name: clair-scan
+                  when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                    - "false"
+                  taskRef:
+                    params:
+                    - name: name
+                      value: clair-scan
+                    resolver: bundles
+                # SAST analysis
+                - name: sast-snyk-check
+                  taskRef:
+                    resolver: bundles
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "tasks", 0, "name"], "roxtl-scan")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# SAST analysis" in ln)
+        assert comment_line == "    # SAST analysis"
+
+    def test_replace_scalar_preserves_end_of_task_comment(self, create_yaml_file):
+        """Comment at end of a task block stays at the key indentation level."""
+        content = dedent("""\
+            spec:
+              tasks:
+                - name: clair-scan
+                  when:
+                  - input: $(params.skip-checks)
+                    operator: in
+                    values:
+                    - "false"
+                  taskRef:
+                    params:
+                    - name: name
+                      value: clair-scan
+                    resolver: bundles
+                  # SAST analysis
+                - name: sast-snyk-check
+                  taskRef:
+                    resolver: bundles
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "tasks", 0, "name"], "roxtl-scan")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# SAST analysis" in ln)
+        assert comment_line == "      # SAST analysis"
+
+    def test_replace_scalar_preserves_intra_task_comment(self, create_yaml_file):
+        """Comment between keys inside a task block keeps its indentation."""
+        content = dedent("""\
+            spec:
+              tasks:
+                - name: clair-scan
+                  # SAST analysis
+                  taskRef:
+                    params:
+                    - name: name
+                      value: clair-scan
+                    resolver: bundles
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "tasks", 0, "name"], "roxtl-scan")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# SAST analysis" in ln)
+        assert comment_line == "      # SAST analysis"
+
+    def test_replace_scalar_preserves_block_scalar_hash_lines(self, create_yaml_file):
+        """Lines starting with # inside block scalars must not have indentation stripped."""
+        content = dedent("""\
+            spec:
+              tasks:
+                - name: clair-scan
+                  params:
+                    - name: custom-script
+                      value: |
+                        #!/usr/bin/env bash
+                        # Set up environment
+                        echo "scanning"
+                        # Run the scan
+                        make scan
+                  taskRef:
+                    params:
+                    - name: name
+                      value: clair-scan
+                    resolver: bundles
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "tasks", 0, "name"], "roxtl-scan")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        shebang_line = next(ln for ln in lines if "#!/usr/bin/env bash" in ln)
+        setup_line = next(ln for ln in lines if "# Set up environment" in ln)
+        scan_line = next(ln for ln in lines if "# Run the scan" in ln)
+        assert shebang_line == "          #!/usr/bin/env bash"
+        assert setup_line == "          # Set up environment"
+        assert scan_line == "          # Run the scan"
+
+    def test_replace_scalar_with_false_multiline_marker(self, create_yaml_file):
+        """A value like :>3 must not be mistaken for a block scalar indicator."""
+        content = dedent("""\
+            spec:
+              pipelineSpec:
+                tasks:
+                - name: foo
+                  wouldYouBelieveThisIsAString: :>3
+                  # some comment
+                  taskRef:
+                    params:
+                    - name: name
+                      value: foo
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "pipelineSpec", "tasks", 0, "name"], "bar")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# some comment" in ln)
+        assert comment_line == "      # some comment"
+
+    def test_replace_scalar_preserves_inline_comment_spacing(self, create_yaml_file):
+        """An inline comment on a sibling key must keep its original spacing."""
+        content = dedent("""\
+            spec:
+              pipelineSpec:
+                tasks:
+                - name: foo
+                  taskRef:  # some comment
+                    params:
+                    - name: name
+                      value: foo
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "pipelineSpec", "tasks", 0, "name"], "bar")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# some comment" in ln)
+        assert "taskRef:  # some comment" in comment_line
+
+    def test_replace_scalar_with_twospace_list_indent(self, create_yaml_file):
+        """Comment indentation is preserved with 2-space block sequence indentation."""
+        content = dedent("""\
+            spec:
+              pipelineSpec:
+                tasks:
+                  - name: foo
+                    # some comment
+                    taskRef:
+                      params:
+                        - name: name
+                          value: foo
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "pipelineSpec", "tasks", 0, "name"], "bar")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        comment_line = next(ln for ln in lines if "# some comment" in ln)
+        assert comment_line == "        # some comment"
+
+    def test_replace_scalar_with_block_scalar_inline_comment(self, create_yaml_file):
+        """Inline comment on a block scalar indicator (|  # hello) is preserved.
+
+        ruamel.yaml stores these comments as plain str objects in ca.items,
+        not as CommentToken.  Without a guard for str, _adjust_comment_token
+        crashes with AttributeError on token.value.
+        """
+        content = dedent("""\
+            spec:
+              tasks:
+                - name: clair-scan
+                  params:
+                    - name: custom-script
+                      value: |  # hello
+                        echo "scanning"
+                        # Run the scan
+                        make scan
+                  taskRef:
+                    params:
+                    - name: name
+                      value: clair-scan
+                    resolver: bundles
+            """)
+        yaml_file = create_yaml_file(content)
+        editor = EditYAMLEntry(yaml_file)
+
+        editor.replace(["spec", "tasks", 0, "name"], "roxtl-scan")
+
+        result = read_file_content(yaml_file)
+        lines = result.splitlines()
+        name_line = next(ln for ln in lines if "roxtl-scan" in ln)
+        assert name_line == "    - name: roxtl-scan"
+        scalar_line = next(ln for ln in lines if "# hello" in ln)
+        assert "value: |  # hello" in scalar_line
+        scan_line = next(ln for ln in lines if "# Run the scan" in ln)
+        assert scan_line == "          # Run the scan"
+
 
 class TestEditYAMLEntryFlowStyle:
     """Tests for handling partial flow-style YAML structures."""


### PR DESCRIPTION
With the new sub-commands that will be added in the PR mentioned below, we would break users comments.

When a scalar replace escalates to a parent block replace, ruamel.yaml preserves absolute column positions for comments while code lines shift to column 0. The subsequent dedent/indent cycle re-indents code lines correctly but over-indents comments by `col` spaces.

Strip `col` characters of leading whitespace from comment-only lines before the dedent/indent cycle so comments stay at their correct relative position within the block. Lines inside block scalars (| / >) are skipped to avoid corrupting literal content that starts with #.

Also updated tests.

### Investigation
I noticed the error while testing the solution of [this PR](https://github.com/konflux-ci/pipeline-migration-tool/pull/137)

<details>
<summary>Investigation</summary>

For testing, I used this file:
```
# Minimal PipelineRun for testing multiple runAfter references to clair-scan
---
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  name: test-pipeline-three
spec:
  params:
  - name: output-image
    value: quay.io/test/image:latest
  - name: skip-checks
    value: "false"
  - name: build-platforms
    value:
    - linux/x86_64
  pipelineSpec:
    params:
    - name: output-image
      type: string
    - default: "false"
      name: skip-checks
      type: string
    - default:
      - linux/x86_64
      name: build-platforms
      type: array
    tasks:
    # Build the image index
    - name: build-image-index
      params:
      - name: IMAGE
        value: $(params.output-image)
      taskRef:
        params:
        - name: name
          value: build-image-index
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3.1@sha256:cc75f64deecccb1b59e96ac1182665a5342d79c9e22eebff63d26b0f00a4319c
        - name: kind
          value: task
        resolver: bundles
    # Scan for vulnerabilities
    - matrix:
        params:
        - name: image-platform
          value:
          - $(params.build-platforms)
      name: clair-scan
      params:
      - name: image-digest
        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
      - name: image-url
        value: $(tasks.build-image-index.results.IMAGE_URL)
      runAfter:
      - build-image-index
      taskRef:
        params:
        - name: name
          value: clair-scan
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:f5b4415db9ac1fba3e11d993a617e0b275d1f0ed2fc669b12c400ed848c39174
        - name: kind
          value: task
        resolver: bundles
      when:
      - input: $(params.skip-checks)
        operator: in
        values:
        - "false"
    # SAST analysis
    - name: sast-snyk-check-oci-ta
      params:
      - name: image-digest
        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
      - name: image-url
        value: $(tasks.build-image-index.results.IMAGE_URL)
      runAfter:
      - build-image-index
      taskRef:
        params:
        - name: name
          value: sast-snyk-check-oci-ta
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:eba24f5d9f4b18aa71e523b9b3dbcf22982aa4b018824260a090b19dfc9abf6f
        - name: kind
          value: task
        resolver: bundles
      when:
      - input: $(params.skip-checks)
        operator: in
        values:
        - "false"
    # Runs after clair-scan only
    - name: rpms-signature-scan
      params:
      - name: image-digest
        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
      - name: image-url
        value: $(tasks.build-image-index.results.IMAGE_URL)
      runAfter:
      - roxtl-scan
      taskRef:
        params:
        - name: name
          value: rpms-signature-scan
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:ccb77d1bf7627fc6241a59ed42bb6e5707a8682754fe8ae18f2cfdddbcf29275
        - name: kind
          value: task
        resolver: bundles
    # Runs after clair-scan and sast-snyk-check
    - name: deprecated-base-image-check
      params:
      - name: IMAGE_URL
        value: $(tasks.build-image-index.results.IMAGE_URL)
      - name: IMAGE_DIGEST
        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
      runAfter:
      - roxtl-scan
      - sast-snyk-check-oci-ta
      taskRef:
        params:
        - name: name
          value: deprecated-image-check
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:0ccc688a77e9b7b0b8973c132a1e840844137e77f887be4a0bec8893b0776872
        - name: kind
          value: task
        resolver: bundles
      when:
      - input: $(params.skip-checks)
        operator: in
        values:
        - "false"
    # Runs after clair-scan and build-image-index
    - name: push-dockerfile
      params:
      - name: IMAGE
        value: $(tasks.build-image-index.results.IMAGE_URL)
      - name: IMAGE_DIGEST
        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
      runAfter:
      - roxtl-scan
      - build-image-index
      taskRef:
        params:
        - name: name
          value: push-dockerfile-oci-ta
        - name: bundle
          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:e19d134048f05dc7c337914b68590699240b92194979bfcc9e1ef4bdf6adb4c4
        - name: kind
          value: task
        resolver: bundles
```

And after running:
```bash
pmt modify -f pipeline-three.yaml task clair-scan rename roxtl-scan --task-ref-name task-roxtl-scan
```
I got (plus 4 spaces):
```diff
-   # SAST analysis
    - name: sast-snyk-check-oci-ta
+      # SAST analysis
    - name: sast-snyk-check-oci-ta
```
Which was in a block which shouldn't be touched.

</details>

